### PR TITLE
Closure test other years

### DIFF
--- a/FakeRateAnalysis/ClosureTestTemplateFits/fit.C
+++ b/FakeRateAnalysis/ClosureTestTemplateFits/fit.C
@@ -24,8 +24,8 @@
 
 
 
-const int NPTBINS=5;
-const float PTBINS[NPTBINS+1] = { 50, 70, 90, 130, 200, 600 };
+const int NPTBINS=9;
+const float PTBINS[NPTBINS+1] = { 50., 70., 90., 110., 130., 150., 200., 250., 300., 600. };
 
 enum hist_t { Real, Fake, Truth, Numerator, Denominator };
 
@@ -53,7 +53,7 @@ TH1* GetHist(int ptbin, bool isEB, hist_t type)
     rootfile=new TFile("diphoton_fake_rate_real_templates_all_GGJets_GJets_76X_MiniAOD_histograms.root");
   else if(type==Truth)
     // Output from PhotonClosure/analysis/MCFakeRateClosureTestWithFakes2.C
-    rootfile=new TFile("diphoton_fake_rate_closure_test_matching_all_samples_80X_MiniAOD_histograms_test.root");
+    rootfile=new TFile("diphoton_fake_rate_closure_test_matching_all_samples_76X_MiniAOD_histograms.root");
   else
     // Output from PhotonClosure/analysis/MCFakeRateAnalysis.C
     rootfile=new TFile("diphoton_fake_rate_closure_test_all_samples_76X_MiniAOD_histograms.root");

--- a/FakeRateAnalysis/DiphotonClosureTest/analysis/DiphotonClosureTest.C
+++ b/FakeRateAnalysis/DiphotonClosureTest/analysis/DiphotonClosureTest.C
@@ -4,8 +4,25 @@
 #include <TStyle.h>
 #include <TCanvas.h>
 
-void DiphotonClosureTest::Loop()
+#include "diphoton-analysis/FakeRateAnalysis/interface/utilities.hh"
+
+void DiphotonClosureTestBase::Loop() {};
+//double DiphotonClosureTestBase::fakeRate(TString region, double pt) {};
+
+class DiphotonClosureTest : public DiphotonClosureTestBase {
+
+public:
+  using DiphotonClosureTestBase::DiphotonClosureTestBase;
+  void Loop() {};
+  void Loop(TString run, TString sample);
+  double fakeRate(TString region, double pt);
+};
+
+
+void DiphotonClosureTest::Loop(TString run, TString sample)
 {
+  int year = run.Atoi();
+
 //   In a ROOT session, you can do:
 //      root> .L DiphotonClosureTest.C
 //      root> DiphotonClosureTest t
@@ -31,23 +48,15 @@ void DiphotonClosureTest::Loop()
 //by  b_branchname->GetEntry(ientry); //read only this branch
   if (fChain == 0) return;
 
-  // input what sample is being run on
-  TString sample = "";
-  cout << "Enter sample being run on (QCD, GJets, GGJets, or all): ";
-  cin >> sample;
-  if (sample != "QCD" && sample != "GJets" && sample != "GGJets" && sample != "all") {
-    cout << "Invalid choice!" << endl;
-    return;
-  }
-  cout << "\nUsing sample: " << sample << endl;
+  std::cout << "\nUsing sample: " << sample << std::endl;
   
   // output filename
   TString filename = "";
-  if (sample == "QCD")     filename = "diphoton_fake_rate_diphoton_closure_test_QCD_Pt_all_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_histograms.root";
-  if (sample == "GJets")   filename = "diphoton_fake_rate_diphoton_closure_test_GJets_HT-all_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_histograms.root";
-  if (sample == "GGJets")  filename = "diphoton_fake_rate_diphoton_closure_test_GGJets_M-all_Pt-50_13TeV-sherpa_76X_MiniAOD_histograms.root";
-  if (sample == "all")     filename = "diphoton_fake_rate_diphoton_closure_test_all_samples_76X_MiniAOD_histograms.root";
-  cout << "Output filename: " << filename << endl << endl;
+  if (sample == "QCD")     filename = "diphoton_fake_rate_diphoton_closure_test_QCD_Pt_all_TuneCUETP8M1_13TeV_pythia8_" + cmssw_version(year) + "_MiniAOD_histograms.root";
+  if (sample == "GJets")   filename = "diphoton_fake_rate_diphoton_closure_test_GJets_HT-all_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_" + cmssw_version(year) + "_MiniAOD_histograms.root";
+  if (sample == "GGJets")  filename = "diphoton_fake_rate_diphoton_closure_test_GGJets_M-all_Pt-50_13TeV-sherpa_" + cmssw_version(year) + "_MiniAOD_histograms.root";
+  if (sample == "all")     filename = "diphoton_fake_rate_diphoton_closure_test_all_samples_" + cmssw_version(year) + "_MiniAOD_histograms.root";
+  std::cout << "Output filename: " << filename << std::endl << std::endl;
 
   int nbins = 120;
   double xmin = 0.0;

--- a/FakeRateAnalysis/DiphotonClosureTest/analysis/DiphotonClosureTest.h
+++ b/FakeRateAnalysis/DiphotonClosureTest/analysis/DiphotonClosureTest.h
@@ -14,7 +14,7 @@
 
 // Header file for the classes stored in the TTree if any.
 
-class DiphotonClosureTest {
+class DiphotonClosureTestBase {
 public :
    TTree          *fChain;   //!pointer to the analyzed TTree or TChain
    Int_t           fCurrent; //!current Tree number in a TChain
@@ -1617,8 +1617,8 @@ public :
    TBranch        *b_isFF;   //!
    TBranch        *b_nPV;   //!
 
-   DiphotonClosureTest(TTree *tree=0);
-   virtual ~DiphotonClosureTest();
+   DiphotonClosureTestBase(TTree *tree=0);
+   virtual ~DiphotonClosureTestBase();
    virtual Int_t    Cut(Long64_t entry);
    virtual Int_t    GetEntry(Long64_t entry);
    virtual Long64_t LoadTree(Long64_t entry);
@@ -1626,13 +1626,13 @@ public :
    virtual void     Loop();
    virtual Bool_t   Notify();
    virtual void     Show(Long64_t entry = -1);
-   virtual double   fakeRate(TString region, double pt);
+   //   virtual double   fakeRate(TString region, double pt) = 0;
 };
 
 #endif
 
 #ifdef DiphotonClosureTest_cxx
-DiphotonClosureTest::DiphotonClosureTest(TTree *tree) : fChain(0) 
+DiphotonClosureTestBase::DiphotonClosureTestBase(TTree *tree) : fChain(0)
 {
 // if parameter tree is not specified (or zero), connect the file
 // used to generate this class and read the Tree.
@@ -1648,19 +1648,19 @@ DiphotonClosureTest::DiphotonClosureTest(TTree *tree) : fChain(0)
    Init(tree);
 }
 
-DiphotonClosureTest::~DiphotonClosureTest()
+DiphotonClosureTestBase::~DiphotonClosureTestBase()
 {
    if (!fChain) return;
    delete fChain->GetCurrentFile();
 }
 
-Int_t DiphotonClosureTest::GetEntry(Long64_t entry)
+Int_t DiphotonClosureTestBase::GetEntry(Long64_t entry)
 {
 // Read contents of entry.
    if (!fChain) return 0;
    return fChain->GetEntry(entry);
 }
-Long64_t DiphotonClosureTest::LoadTree(Long64_t entry)
+Long64_t DiphotonClosureTestBase::LoadTree(Long64_t entry)
 {
 // Set the environment to read one entry
    if (!fChain) return -5;
@@ -1673,7 +1673,7 @@ Long64_t DiphotonClosureTest::LoadTree(Long64_t entry)
    return centry;
 }
 
-void DiphotonClosureTest::Init(TTree *tree)
+void DiphotonClosureTestBase::Init(TTree *tree)
 {
    // The Init() function is called when the selector needs to initialize
    // a new tree or chain. Typically here the branch addresses and branch
@@ -1723,7 +1723,7 @@ void DiphotonClosureTest::Init(TTree *tree)
    Notify();
 }
 
-Bool_t DiphotonClosureTest::Notify()
+Bool_t DiphotonClosureTestBase::Notify()
 {
    // The Notify() function is called when a new file is opened. This
    // can be either for a new TTree in a TChain or when when a new TTree
@@ -1734,14 +1734,14 @@ Bool_t DiphotonClosureTest::Notify()
    return kTRUE;
 }
 
-void DiphotonClosureTest::Show(Long64_t entry)
+void DiphotonClosureTestBase::Show(Long64_t entry)
 {
 // Print contents of entry.
 // If entry is not specified, print current entry
    if (!fChain) return;
    fChain->Show(entry);
 }
-Int_t DiphotonClosureTest::Cut(Long64_t entry)
+Int_t DiphotonClosureTestBase::Cut(Long64_t entry)
 {
 // This function may be called from Loop.
 // returns  1 if entry is accepted.

--- a/FakeRateAnalysis/DiphotonClosureTest/scripts/diphoton_looper.C
+++ b/FakeRateAnalysis/DiphotonClosureTest/scripts/diphoton_looper.C
@@ -6,20 +6,11 @@
 #include "TStopwatch.h"
 #include <iostream>
 
-#include "DiphotonClosureTest.C"
+#include "diphoton-analysis/FakeRateAnalysis/DiphotonClosureTest/analysis/DiphotonClosureTest.C"
 
-using namespace std;
-
-void diphoton_looper() {
-  // input what sample to run on
-  TString sample = "";
-  cout << "Enter sample being run on (QCD, GJets, GGJets, or all): ";
-  cin >> sample;
-  if (sample != "QCD" && sample != "GJets" && sample != "GGJets" && sample != "all") {
-    cout << "Invalid choice!" << endl;
-    return;
-  }
-  cout << "\nUsing sample: " << sample << endl;
+void diphoton_looper(TString run, TString sample)
+{
+  std::cout << "\nUsing sample: " << sample << std::endl;
   
   // use stopwatch for timing
   TStopwatch sw;
@@ -29,57 +20,101 @@ void diphoton_looper() {
   TString tree = "diphoton/fTree";
   
   // ntuple path (change as needed)
-  TString ntuple_path = "/store/user/abuccill/diphoton-analysis/fake_rate_diphoton_closure_test";
+  TString ntuple_path("root://cmseos.fnal.gov//store/user/cawest/");
   
   // create tchain of all files to loop over
   TChain *chain = new TChain(tree);
 
-  if (sample == "all" || sample == "QCD") {
-    // chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_5to10_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0); 
-    // chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_10to15_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    // chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_15to30_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    // chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_30to50_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_50to80_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_80to120_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_120to170_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_170to300_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_300to470_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+  // currently using legacy samples for 2016
+  if (run == "2016") {
+    ntuple_path = "root://cmseos.fnal.gov//store/user/abuccill/diphoton-analysis/fake_rate_diphoton_closure_test";
+
+    if (sample == "all" || sample == "QCD") {
+      // chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_5to10_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      // chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_10to15_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      // chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_15to30_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      // chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_30to50_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_50to80_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_80to120_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_120to170_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_170to300_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_300to470_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+    }
+
+    if (sample == "all" || sample == "GJets") {
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GJets_HT-40To100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GJets_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GJets_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GJets_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_merged.root",0);
+    }
+
+    if (sample == "all" || sample == "GGJets") {
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GGJets_M-60To200_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GGJets_M-200To500_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GGJets_M-500To1000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GGJets_M-1000To2000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GGJets_M-2000To4000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GGJets_M-4000To6000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GGJets_M-6000To8000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
+      chain->Add(ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GGJets_M-8000To13000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
+    }
   }
-  
-  if (sample == "all" || sample == "GJets") {
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GJets_HT-40To100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GJets_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GJets_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GJets_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_merged.root",0);
+  if (run == "2017") {
+    if (sample == "all" || sample == "GJets") {
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8__Fall17-v2__MINIAODSIM_resub/200904_235904/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8__Fall17-v1__MINIAODSIM_resub/200905_000007/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8__Fall17-v1__MINIAODSIM_resub/200905_000330/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8__Fall17-v1__MINIAODSIM_resub/200905_000726/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8__Fall17-v2__MINIAODSIM_resub/200905_000637/0000/*.root");
+    }
+    if (sample == "all" || sample == "GGJets") {
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-60To200_Pt-50_13TeV-sherpa/crab_GGJets_M-60To200_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/200904_233439/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-200To500_Pt-50_13TeV-sherpa/crab_GGJets_M-200To500_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/200904_232918/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-500To1000_Pt-50_13TeV-sherpa/crab_GGJets_M-500To1000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/200904_233026/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-1000To2000_Pt-50_13TeV-sherpa/crab_GGJets_M-1000To2000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/200904_232739/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-2000To4000_Pt-50_13TeV-sherpa/crab_GGJets_M-2000To4000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v2__MINIAODSIM_resub/200904_233559/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-4000To6000_Pt-50_13TeV-sherpa/crab_GGJets_M-4000To6000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v2__MINIAODSIM_resub/200904_233641/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-6000To8000_Pt-50_13TeV-sherpa/crab_GGJets_M-6000To8000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/200904_233321/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-8000To13000_Pt-50_13TeV-sherpa/crab_GGJets_M-8000To13000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/200904_233735/0000/*.root");
+    }
   }
+  if (run == "2018") {
+    if (sample == "all" || sample == "GJets") {
+      chain->Add(ntuple_path+"diphoton_closure/11c96ff/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic/200821_031620/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/11c96ff/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8__RunIIAutumn18MiniAOD-4cores5k_102X_upgrade2018/200821_021447/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/11c96ff/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8__RunIIAutumn18MiniAOD-102X_upgrade2018_realisti/200821_023518/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/11c96ff/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8__RunIIAutumn18MiniAOD-102X_upgrade2018_realisti/200821_025548/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/11c96ff/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8__RunIIAutumn18MiniAOD-102X_upgrade2018_realisti/200821_033205/0000/*.root");
+    }
   
-  if (/*sample == "all" || */sample == "GGJets") {
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GGJets_M-60To200_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GGJets_M-200To500_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GGJets_M-500To1000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GGJets_M-1000To2000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GGJets_M-2000To4000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GGJets_M-4000To6000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GGJets_M-6000To8000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_diphoton_closure_test_GGJets_M-8000To13000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
+    if (sample == "all" || sample == "GGJets") {
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-500To1000_Pt-50_13TeV-sherpa/crab_GGJets_M-500To1000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MINI/200730_042411/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-8000To13000_Pt-50_13TeV-sherpa/crab_GGJets_M-8000To13000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MI/200730_151230/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-2000To4000_Pt-50_13TeV-sherpa/crab_GGJets_M-2000To4000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MIN/200730_151014/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-6000To8000_Pt-50_13TeV-sherpa/crab_GGJets_M-6000To8000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MIN/200730_151138/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-4000To6000_Pt-50_13TeV-sherpa/crab_GGJets_M-4000To6000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MIN/200730_151111/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-1000To2000_Pt-50_13TeV-sherpa/crab_GGJets_M-1000To2000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MIN/200730_150946/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-60To200_Pt-50_13TeV-sherpa/crab_GGJets_M-60To200_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MINIAO/200730_151203/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-200To500_Pt-50_13TeV-sherpa/crab_GGJets_M-200To500_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MINIA/200730_151042/0000/*.root");
+    }
   }
   
   // list chain and entries
   chain->ls();
-  cout << "Total number of entries: " << chain->GetEntries() << endl;
+  std::cout << "Total number of entries: " << chain->GetEntries() << std::endl;
   
   // create instance using our chain and loop over entries
   DiphotonClosureTest loop(chain);
-  loop.Loop();
+  loop.Loop(run, sample);
   
   // stop stopwatch
   sw.Stop();

--- a/FakeRateAnalysis/PhotonClosureTest/analysis/MCFakeRateClosureTest.C
+++ b/FakeRateAnalysis/PhotonClosureTest/analysis/MCFakeRateClosureTest.C
@@ -4,8 +4,26 @@
 #include <TStyle.h>
 #include <TCanvas.h>
 
-void MCFakeRateClosureTest::Loop()
+#include "diphoton-analysis/FakeRateAnalysis/interface/utilities.hh"
+
+void MCFakeRateClosureTestBase::Loop() {};
+
+class MCFakeRateClosureTest : public MCFakeRateClosureTestBase {
+
+public:
+  using MCFakeRateClosureTestBase::MCFakeRateClosureTestBase;
+  void Loop() {};
+  void Loop(TString run, TString sample);
+  double FakeRateEB(double pt);
+  double FakeRateEE(double pt);
+};
+
+
+
+void MCFakeRateClosureTest::Loop(TString run, TString sample)
 {
+  int year = run.Atoi();
+
 //   In a ROOT session, you can do:
 //      root> .L MCFakeRateClosureTest.C
 //      root> MCFakeRateClosureTest t
@@ -30,24 +48,14 @@ void MCFakeRateClosureTest::Loop()
 //    fChain->GetEntry(jentry);       //read all branches
 //by  b_branchname->GetEntry(ientry); //read only this branch
   if (fChain == 0) return;
-
-  // input what sample is being run on
-  TString sample = "";
-  cout << "Enter sample being run on (QCD, GJets, GGJets, or all): ";
-  cin >> sample;
-  if (sample != "QCD" && sample != "GJets" && sample != "GGJets" && sample != "all") {
-    cout << "Invalid choice!" << endl;
-    return;
-  }
-  cout << "\nUsing sample: " << sample << endl;
   
   // output filename
   TString filename = "";
-  if (sample == "QCD")    filename = "diphoton_fake_rate_closure_test_QCD_Pt_all_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_histograms.root";
-  if (sample == "GJets")  filename = "diphoton_fake_rate_closure_test_GJets_HT-all_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_histograms.root";
-  if (sample == "GGJets") filename = "diphoton_fake_rate_closure_test_GGJets_M-all_Pt-50_13TeV-sherpa_76X_MiniAOD_histograms.root";
-  if (sample == "all")    filename = "diphoton_fake_rate_closure_test_all_samples_76X_MiniAOD_histograms.root";
-  cout << "Output filename: " << filename << endl << endl;
+  if (sample == "QCD")    filename = "diphoton_fake_rate_closure_test_QCD_Pt_all_TuneCUETP8M1_13TeV_pythia8_" + cmssw_version(year) + "_MiniAOD_histograms.root";
+  if (sample == "GJets")  filename = "diphoton_fake_rate_closure_test_GJets_HT-all_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_" + cmssw_version(year) + "_MiniAOD_histograms.root";
+  if (sample == "GGJets") filename = "diphoton_fake_rate_closure_test_GGJets_M-all_Pt-50_13TeV-sherpa_" + cmssw_version(year) + "_MiniAOD_histograms.root";
+  if (sample == "all")    filename = "diphoton_fake_rate_closure_test_all_samples_" + cmssw_version(year) + "_MiniAOD_histograms.root";
+  std::cout << "Output filename: " << filename << std::endl << std::endl;
   
   // count number of numerator photons
   int nNumerator              = 0;
@@ -443,10 +451,10 @@ void MCFakeRateClosureTest::Loop()
     
   } // end loop over entries
   
-  cout << endl;
-  cout << "Number of numerator photons: " << nNumerator << endl;
-  cout << " ...passing sipip cut      : " << nNumerator_passSipipCut << endl;
-  cout << endl;
+  std::cout << std::endl;
+  std::cout << "Number of numerator photons: " << nNumerator << std::endl;
+  std::cout << " ...passing sipip cut      : " << nNumerator_passSipipCut << std::endl;
+  std::cout << std::endl;
 
   // create output file
   TFile file_out(filename,"RECREATE");
@@ -455,115 +463,115 @@ void MCFakeRateClosureTest::Loop()
   // variable binned
   phoPtEB_denominator_varbin.Write();
   phoPtEE_denominator_varbin.Write();
-  cout << phoPtEB_denominator_varbin.GetName() << "\t integral: " << phoPtEB_denominator_varbin.Integral() << endl;
-  cout << phoPtEE_denominator_varbin.GetName() << "\t integral: " << phoPtEE_denominator_varbin.Integral() << endl;
+  std::cout << phoPtEB_denominator_varbin.GetName() << "\t integral: " << phoPtEB_denominator_varbin.Integral() << std::endl;
+  std::cout << phoPtEE_denominator_varbin.GetName() << "\t integral: " << phoPtEE_denominator_varbin.Integral() << std::endl;
   // all objects
   photon_pt_denominator_EB->Write();
   photon_pt_denominator_EE->Write();
-  cout << photon_pt_denominator_EB->GetName() << "\t integral: " << photon_pt_denominator_EB->Integral() << endl;
-  cout << photon_pt_denominator_EE->GetName() << "\t integral: " << photon_pt_denominator_EE->Integral() << endl;
+  std::cout << photon_pt_denominator_EB->GetName() << "\t integral: " << photon_pt_denominator_EB->Integral() << std::endl;
+  std::cout << photon_pt_denominator_EE->GetName() << "\t integral: " << photon_pt_denominator_EE->Integral() << std::endl;
   photon_eta_denominator_EB->Write();
   photon_eta_denominator_EE->Write();
-  cout << photon_eta_denominator_EB->GetName() << "\t integral: " << photon_eta_denominator_EB->Integral() << endl;
-  cout << photon_eta_denominator_EE->GetName() << "\t integral: " << photon_eta_denominator_EE->Integral() << endl;
+  std::cout << photon_eta_denominator_EB->GetName() << "\t integral: " << photon_eta_denominator_EB->Integral() << std::endl;
+  std::cout << photon_eta_denominator_EE->GetName() << "\t integral: " << photon_eta_denominator_EE->Integral() << std::endl;
   photon_phi_denominator_EB->Write();
   photon_phi_denominator_EE->Write();
-  cout << photon_phi_denominator_EB->GetName() << "\t integral: " << photon_phi_denominator_EB->Integral() << endl;
-  cout << photon_phi_denominator_EE->GetName() << "\t integral: " << photon_phi_denominator_EE->Integral() << endl;
+  std::cout << photon_phi_denominator_EB->GetName() << "\t integral: " << photon_phi_denominator_EB->Integral() << std::endl;
+  std::cout << photon_phi_denominator_EE->GetName() << "\t integral: " << photon_phi_denominator_EE->Integral() << std::endl;
   // fake rate weighted
   photon_pt_denominator_fake_rate_weighted_EB->Write();
   photon_pt_denominator_fake_rate_weighted_EE->Write();
-  cout << photon_pt_denominator_fake_rate_weighted_EB->GetName() << "\t integral: " << photon_pt_denominator_fake_rate_weighted_EB->Integral() << endl;
-  cout << photon_pt_denominator_fake_rate_weighted_EE->GetName() << "\t integral: " << photon_pt_denominator_fake_rate_weighted_EE->Integral() << endl;
+  std::cout << photon_pt_denominator_fake_rate_weighted_EB->GetName() << "\t integral: " << photon_pt_denominator_fake_rate_weighted_EB->Integral() << std::endl;
+  std::cout << photon_pt_denominator_fake_rate_weighted_EE->GetName() << "\t integral: " << photon_pt_denominator_fake_rate_weighted_EE->Integral() << std::endl;
   photon_eta_denominator_fake_rate_weighted_EB->Write();
   photon_eta_denominator_fake_rate_weighted_EE->Write();
-  cout << photon_eta_denominator_fake_rate_weighted_EB->GetName() << "\t integral: " << photon_eta_denominator_fake_rate_weighted_EB->Integral() << endl;
-  cout << photon_eta_denominator_fake_rate_weighted_EE->GetName() << "\t integral: " << photon_eta_denominator_fake_rate_weighted_EE->Integral() << endl;
+  std::cout << photon_eta_denominator_fake_rate_weighted_EB->GetName() << "\t integral: " << photon_eta_denominator_fake_rate_weighted_EB->Integral() << std::endl;
+  std::cout << photon_eta_denominator_fake_rate_weighted_EE->GetName() << "\t integral: " << photon_eta_denominator_fake_rate_weighted_EE->Integral() << std::endl;
   photon_phi_denominator_fake_rate_weighted_EB->Write();
   photon_phi_denominator_fake_rate_weighted_EE->Write();
-  cout << photon_phi_denominator_fake_rate_weighted_EB->GetName() << "\t integral: " << photon_phi_denominator_fake_rate_weighted_EB->Integral() << endl;
-  cout << photon_phi_denominator_fake_rate_weighted_EE->GetName() << "\t integral: " << photon_phi_denominator_fake_rate_weighted_EE->Integral() << endl;
+  std::cout << photon_phi_denominator_fake_rate_weighted_EB->GetName() << "\t integral: " << photon_phi_denominator_fake_rate_weighted_EB->Integral() << std::endl;
+  std::cout << photon_phi_denominator_fake_rate_weighted_EE->GetName() << "\t integral: " << photon_phi_denominator_fake_rate_weighted_EE->Integral() << std::endl;
   
   // write sieie numerator histograms
-  for (vector<TH1D*>::iterator it = sIeIeNumeratorEB.begin() ; it != sIeIeNumeratorEB.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = sIeIeNumeratorEB.begin() ; it != sIeIeNumeratorEB.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = sIeIeNumeratorEE.begin() ; it != sIeIeNumeratorEE.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = sIeIeNumeratorEE.begin() ; it != sIeIeNumeratorEE.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
 
   // write chIso numerator histograms
-  for (vector<TH1D*>::iterator it = chIsoNumeratorEB.begin() ; it != chIsoNumeratorEB.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = chIsoNumeratorEB.begin() ; it != chIsoNumeratorEB.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = chIsoNumeratorEE.begin() ; it != chIsoNumeratorEE.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = chIsoNumeratorEE.begin() ; it != chIsoNumeratorEE.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
 
   // write denominator histograms
-  for (vector<TH1D*>::iterator it = denomPtEB.begin() ; it != denomPtEB.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = denomPtEB.begin() ; it != denomPtEB.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = denomPtEE.begin() ; it != denomPtEE.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = denomPtEE.begin() ; it != denomPtEE.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
 
   // write PV histograms
   //
   // photonIso
-  for (vector<TH1D*>::iterator it = photonIsoEB.begin() ; it != photonIsoEB.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = photonIsoEB.begin() ; it != photonIsoEB.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = photonIsoEB1.begin() ; it != photonIsoEB1.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = photonIsoEB1.begin() ; it != photonIsoEB1.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = photonIsoEB2.begin() ; it != photonIsoEB2.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = photonIsoEB2.begin() ; it != photonIsoEB2.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = photonIsoEE.begin() ; it != photonIsoEE.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = photonIsoEE.begin() ; it != photonIsoEE.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = photonIsoEE1.begin() ; it != photonIsoEE1.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = photonIsoEE1.begin() ; it != photonIsoEE1.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = photonIsoEE2.begin() ; it != photonIsoEE2.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = photonIsoEE2.begin() ; it != photonIsoEE2.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
   // corPhotonIso
-  for (vector<TH1D*>::iterator it = corPhotonIsoEB.begin() ; it != corPhotonIsoEB.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = corPhotonIsoEB.begin() ; it != corPhotonIsoEB.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = corPhotonIsoEB1.begin() ; it != corPhotonIsoEB1.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = corPhotonIsoEB1.begin() ; it != corPhotonIsoEB1.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = corPhotonIsoEB2.begin() ; it != corPhotonIsoEB2.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = corPhotonIsoEB2.begin() ; it != corPhotonIsoEB2.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = corPhotonIsoEE.begin() ; it != corPhotonIsoEE.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = corPhotonIsoEE.begin() ; it != corPhotonIsoEE.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = corPhotonIsoEE1.begin() ; it != corPhotonIsoEE1.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = corPhotonIsoEE1.begin() ; it != corPhotonIsoEE1.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = corPhotonIsoEE2.begin() ; it != corPhotonIsoEE2.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = corPhotonIsoEE2.begin() ; it != corPhotonIsoEE2.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
 
@@ -572,10 +580,10 @@ void MCFakeRateClosureTest::Loop()
     for (unsigned int j = 0; j < chIsoSidebands.size(); j++) {
       TH1D* tempHistEB = sIeIeFakeTemplatesEB.at(i).at(j);
       TH1D* tempHistEE = sIeIeFakeTemplatesEE.at(i).at(j);
-      cout << tempHistEB->GetName() << "\t integral: " << tempHistEB->Integral() << endl;
+      std::cout << tempHistEB->GetName() << "\t integral: " << tempHistEB->Integral() << std::endl;
       tempHistEB->Scale(1./tempHistEB->Integral());
       tempHistEB->Write();
-      cout << tempHistEE->GetName() << "\t integral: " << tempHistEE->Integral() << endl;
+      std::cout << tempHistEE->GetName() << "\t integral: " << tempHistEE->Integral() << std::endl;
       tempHistEE->Scale(1./tempHistEE->Integral());
       tempHistEE->Write();
     }
@@ -586,14 +594,14 @@ void MCFakeRateClosureTest::Loop()
     // EB
     for (unsigned int j = 0; j < sieie_EB_sidebands.size(); j++) {
       TH1D* tempHistEB = chIsoFakeTemplatesEB.at(i).at(j);
-      cout << tempHistEB->GetName() << "\t integral: " << tempHistEB->Integral() << endl;
+      std::cout << tempHistEB->GetName() << "\t integral: " << tempHistEB->Integral() << std::endl;
       tempHistEB->Scale(1./tempHistEB->Integral());
       tempHistEB->Write();
     }
     // EE
     for (unsigned int j = 0; j < sieie_EE_sidebands.size(); j++) {
       TH1D* tempHistEE = chIsoFakeTemplatesEE.at(i).at(j);
-      cout << tempHistEE->GetName() << "\t integral: " << tempHistEE->Integral() << endl;
+      std::cout << tempHistEE->GetName() << "\t integral: " << tempHistEE->Integral() << std::endl;
       tempHistEE->Scale(1./tempHistEE->Integral());
       tempHistEE->Write();
     }

--- a/FakeRateAnalysis/PhotonClosureTest/analysis/MCFakeRateClosureTest.h
+++ b/FakeRateAnalysis/PhotonClosureTest/analysis/MCFakeRateClosureTest.h
@@ -16,7 +16,7 @@
 #include "vector"
 #include "vector"
 
-class MCFakeRateClosureTest {
+class MCFakeRateClosureTestBase {
 public :
    TTree          *fChain;   //!pointer to the analyzed TTree or TChain
    Int_t           fCurrent; //!current Tree number in a TChain
@@ -951,16 +951,16 @@ public :
    Bool_t          Photon_isDenominatorObj;
    Bool_t          Photon_isSaturated;
    Int_t           PhotonRealMatch;
-   vector<double>  *VertexCollInfo_vx;
-   vector<double>  *VertexCollInfo_vy;
-   vector<double>  *VertexCollInfo_vz;
-   vector<double>  *VertexCollInfo_vxError;
-   vector<double>  *VertexCollInfo_vyError;
-   vector<double>  *VertexCollInfo_vzError;
-   vector<double>  *VertexCollInfo_ndof;
-   vector<double>  *VertexCollInfo_d0;
-   vector<int>     *VertexCollInfo_nTracks;
-   vector<int>     *VertexCollInfo_isFake;
+   std::vector<double>  *VertexCollInfo_vx;
+   std::vector<double>  *VertexCollInfo_vy;
+   std::vector<double>  *VertexCollInfo_vz;
+   std::vector<double>  *VertexCollInfo_vxError;
+   std::vector<double>  *VertexCollInfo_vyError;
+   std::vector<double>  *VertexCollInfo_vzError;
+   std::vector<double>  *VertexCollInfo_ndof;
+   std::vector<double>  *VertexCollInfo_d0;
+   std::vector<int>     *VertexCollInfo_nTracks;
+   std::vector<int>     *VertexCollInfo_isFake;
 
    // List of branches
    TBranch        *b_Event;   //!
@@ -980,8 +980,8 @@ public :
    TBranch        *b_VertexCollInfo_nTracks;   //!
    TBranch        *b_VertexCollInfo_isFake;   //!
 
-   MCFakeRateClosureTest(TTree *tree=0);
-   virtual ~MCFakeRateClosureTest();
+   MCFakeRateClosureTestBase(TTree *tree=0);
+   virtual ~MCFakeRateClosureTestBase();
    virtual Int_t    Cut(Long64_t entry);
    virtual Int_t    GetEntry(Long64_t entry);
    virtual Long64_t LoadTree(Long64_t entry);
@@ -989,14 +989,12 @@ public :
    virtual void     Loop();
    virtual Bool_t   Notify();
    virtual void     Show(Long64_t entry = -1);
-   virtual double   FakeRateEB(double pt);
-   virtual double   FakeRateEE(double pt);
 };
 
 #endif
 
 #ifdef MCFakeRateClosureTest_cxx
-MCFakeRateClosureTest::MCFakeRateClosureTest(TTree *tree) : fChain(0) 
+MCFakeRateClosureTestBase::MCFakeRateClosureTestBase(TTree *tree) : fChain(0)
 {
 // if parameter tree is not specified (or zero), connect the file
 // used to generate this class and read the Tree.
@@ -1012,19 +1010,19 @@ MCFakeRateClosureTest::MCFakeRateClosureTest(TTree *tree) : fChain(0)
    Init(tree);
 }
 
-MCFakeRateClosureTest::~MCFakeRateClosureTest()
+MCFakeRateClosureTestBase::~MCFakeRateClosureTestBase()
 {
    if (!fChain) return;
    delete fChain->GetCurrentFile();
 }
 
-Int_t MCFakeRateClosureTest::GetEntry(Long64_t entry)
+Int_t MCFakeRateClosureTestBase::GetEntry(Long64_t entry)
 {
 // Read contents of entry.
    if (!fChain) return 0;
    return fChain->GetEntry(entry);
 }
-Long64_t MCFakeRateClosureTest::LoadTree(Long64_t entry)
+Long64_t MCFakeRateClosureTestBase::LoadTree(Long64_t entry)
 {
 // Set the environment to read one entry
    if (!fChain) return -5;
@@ -1037,7 +1035,7 @@ Long64_t MCFakeRateClosureTest::LoadTree(Long64_t entry)
    return centry;
 }
 
-void MCFakeRateClosureTest::Init(TTree *tree)
+void MCFakeRateClosureTestBase::Init(TTree *tree)
 {
    // The Init() function is called when the selector needs to initialize
    // a new tree or chain. Typically here the branch addresses and branch
@@ -1083,7 +1081,7 @@ void MCFakeRateClosureTest::Init(TTree *tree)
    Notify();
 }
 
-Bool_t MCFakeRateClosureTest::Notify()
+Bool_t MCFakeRateClosureTestBase::Notify()
 {
    // The Notify() function is called when a new file is opened. This
    // can be either for a new TTree in a TChain or when when a new TTree
@@ -1094,14 +1092,14 @@ Bool_t MCFakeRateClosureTest::Notify()
    return kTRUE;
 }
 
-void MCFakeRateClosureTest::Show(Long64_t entry)
+void MCFakeRateClosureTestBase::Show(Long64_t entry)
 {
 // Print contents of entry.
 // If entry is not specified, print current entry
    if (!fChain) return;
    fChain->Show(entry);
 }
-Int_t MCFakeRateClosureTest::Cut(Long64_t entry)
+Int_t MCFakeRateClosureTestBase::Cut(Long64_t entry)
 {
 // This function may be called from Loop.
 // returns  1 if entry is accepted.

--- a/FakeRateAnalysis/PhotonClosureTest/analysis/MCFakeRateClosureTestWithFakes.C
+++ b/FakeRateAnalysis/PhotonClosureTest/analysis/MCFakeRateClosureTestWithFakes.C
@@ -4,8 +4,24 @@
 #include <TStyle.h>
 #include <TCanvas.h>
 
-void MCFakeRateClosureTestWithFakes::Loop()
+#include <iomanip>
+
+#include "diphoton-analysis/FakeRateAnalysis/interface/utilities.hh"
+
+void MCFakeRateClosureTestWithFakesBase::Loop() {};
+
+class MCFakeRateClosureTestWithFakes : public MCFakeRateClosureTestWithFakesBase {
+
+public:
+  using MCFakeRateClosureTestWithFakesBase::MCFakeRateClosureTestWithFakesBase;
+  void Loop() {};
+  void Loop(TString run, TString sample);
+};
+
+
+void MCFakeRateClosureTestWithFakes::Loop(TString run, TString sample)
 {
+  int year = run.Atoi();
 //   In a ROOT session, you can do:
 //      root> .L MCFakeRateClosureTestWithFakes.C
 //      root> MCFakeRateClosureTestWithFakes t
@@ -31,22 +47,14 @@ void MCFakeRateClosureTestWithFakes::Loop()
 //by  b_branchname->GetEntry(ientry); //read only this branch
   if (fChain == 0) return;
 
-  // input what sample is being run on
-  TString sample = "";
-  cout << "Enter sample being run on (QCD, GJets, GGJets, or all): ";
-  cin >> sample;
-  if (sample != "QCD" && sample != "GJets" && sample != "GGJets" && sample != "all") {
-    cout << "Invalid choice!" << endl;
-    return;
-  }
-  cout << "\nUsing sample: " << sample << endl;
+  std::cout << "\nUsing sample: " << sample << std::endl;
 
   TString filename = "";
-  if (sample == "QCD")    filename = "diphoton_fake_rate_closure_test_matching_QCD_Pt_all_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_histograms.root";
-  if (sample == "GJets")  filename = "diphoton_fake_rate_closure_test_matching_GJets_HT-all_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_histograms.root";
-  if (sample == "GGJets") filename = "diphoton_fake_rate_closure_test_matching_GGJets_M-all_Pt-50_13TeV-sherpa_76X_MiniAOD_histograms.root";
-  if (sample == "all")    filename = "diphoton_fake_rate_closure_test_matching_all_samples_76X_MiniAOD_histograms.root";
-  cout << "\nfilename: " << filename << endl << endl;
+  if (sample == "QCD")    filename = "diphoton_fake_rate_closure_test_matching_QCD_Pt_all_TuneCUETP8M1_13TeV_pythia8_" + cmssw_version(year) + "_MiniAOD_histograms.root";
+  if (sample == "GJets")  filename = "diphoton_fake_rate_closure_test_matching_GJets_HT-all_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_" + cmssw_version(year) + "_MiniAOD_histograms.root";
+  if (sample == "GGJets") filename = "diphoton_fake_rate_closure_test_matching_GGJets_M-all_Pt-50_13TeV-sherpa_" + cmssw_version(year) + "_MiniAOD_histograms.root";
+  if (sample == "all")    filename = "diphoton_fake_rate_closure_test_matching_all_samples_" + cmssw_version(year) + "_MiniAOD_histograms.root";
+  std::cout << "\nfilename: " << filename << std::endl << std::endl;
   
   // event counters
   int nEvents = 0;
@@ -403,7 +411,8 @@ void MCFakeRateClosureTestWithFakes::Loop()
   }
   
   Long64_t nentries = fChain->GetEntriesFast();
-  
+  std::cout << "Total entries: " << nentries << std::endl;
+
   bool printdRConInfo = false;
   
   Long64_t nbytes = 0, nb = 0;
@@ -418,7 +427,7 @@ void MCFakeRateClosureTestWithFakes::Loop()
     // fake rate object definitions
     bool is_sieie_numerator_object = Photon_isNumeratorObjCand && Photon_passChIso;
     bool is_chIso_numerator_object = Photon_isNumeratorObjCand && Photon_passSieie;
-    bool is_sieie_sideband_object = Photon_isNumeratorObjCand && (5.0 < Photon_chargedHadIso03) && (Photon_chargedHadIso03 < 10.0);
+    //    bool is_sieie_sideband_object = Photon_isNumeratorObjCand && (5.0 < Photon_chargedHadIso03) && (Photon_chargedHadIso03 < 10.0);
     
     // reject beam halo
     // if (Event_beamHaloIDTight2015) continue;
@@ -743,13 +752,13 @@ void MCFakeRateClosureTestWithFakes::Loop()
 	  if (Photon_passSieie) gen_photon_reco_photon_pt_diff_EB_passSieie->Fill( PhotonGenMatch_pt/Photon_pt,Event_weightAll );
 	  if (!Photon_passSieie) gen_photon_reco_photon_pt_diff_EB_failSieie->Fill( PhotonGenMatch_pt/Photon_pt,Event_weightAll );
 	  if (printdRConInfo) {
-	    cout << endl;
-	    cout << "Run: " << Event_run << ", LS: " << Event_LS << ", event number: " << Event_evnum << ", weight = " << Event_weightAll <<  endl;
-	    cout << "EB; final state (status 1); dR <= 0.1; numerator (no sieie cut)" << endl;
-	    cout << "Reco photon: pt = " << Photon_pt << "; sc_eta = " << Photon_scEta << "; eta = " << Photon_eta << "; phi = " << Photon_phi << "; sieie = " << Photon_sigmaIetaIeta5x5
-		 << "; isSaturated = " << Photon_isSaturated << "; passSieie = " << Photon_passSieie << endl;
-	    cout << "Photon gen match: pt = " << PhotonGenMatch_pt << "; eta = " << PhotonGenMatch_eta << "; phi = " << PhotonGenMatch_phi << endl;
-	    cout << "gen_pt / reco_pt: " << PhotonGenMatch_pt/Photon_pt << endl;
+	    std::cout << std::endl;
+	    std::cout << "Run: " << Event_run << ", LS: " << Event_LS << ", event number: " << Event_evnum << ", weight = " << Event_weightAll <<  std::endl;
+	    std::cout << "EB; final state (status 1); dR <= 0.1; numerator (no sieie cut)" << std::endl;
+	    std::cout << "Reco photon: pt = " << Photon_pt << "; sc_eta = " << Photon_scEta << "; eta = " << Photon_eta << "; phi = " << Photon_phi << "; sieie = " << Photon_sigmaIetaIeta5x5
+		 << "; isSaturated = " << Photon_isSaturated << "; passSieie = " << Photon_passSieie << std::endl;
+	    std::cout << "Photon gen match: pt = " << PhotonGenMatch_pt << "; eta = " << PhotonGenMatch_eta << "; phi = " << PhotonGenMatch_phi << std::endl;
+	    std::cout << "gen_pt / reco_pt: " << PhotonGenMatch_pt/Photon_pt << std::endl;
 	  }
 	  int nParticlesEB = GenMatchPt->size();
 	  double particlesSumPtEB = 0;
@@ -767,10 +776,10 @@ void MCFakeRateClosureTestWithFakes::Loop()
 	    if (add_first_element_EB) distinct_moms_EB.push_back(std::make_pair(GenMatchMotherPdgId->at(pos),GenMatchMotherPt->at(pos)));
 	    add_first_element_EB = false;
 	    if (printdRConInfo) {
-	      cout << "Particle " << pos << ": pdgId: " << GenMatchPdgId->at(pos) << "; pt: " << GenMatchPt->at(pos)
+	      std::cout << "Particle " << pos << ": pdgId: " << GenMatchPdgId->at(pos) << "; pt: " << GenMatchPt->at(pos)
 		   << "; eta: " << GenMatchEta->at(pos) << "; phi: " << GenMatchPhi->at(pos) << "; dR: " << GenMatchDeltaR->at(pos)
 		   << "; nMothers: " << GenMatchNumMothers->at(pos) << "; mother pdgId: " << GenMatchMotherPdgId->at(pos)
-		   << "; mother pt: " << GenMatchMotherPt->at(pos) << "; mother status: " << GenMatchMotherStatus->at(pos) << endl;
+		   << "; mother pt: " << GenMatchMotherPt->at(pos) << "; mother status: " << GenMatchMotherStatus->at(pos) << std::endl;
 	    }
 	    for (std::vector<std::pair<int, double> >::iterator it = distinct_moms_EB.begin(); it != distinct_moms_EB.end(); ++it) {
 	      if (it->first == GenMatchMotherPdgId->at(pos) && it->second == GenMatchMotherPt->at(pos)) {
@@ -795,16 +804,16 @@ void MCFakeRateClosureTestWithFakes::Loop()
 	    }
 	  } // end loop through final state particles in dR cone
 	  if (printdRConInfo) {
-	    cout << "nParticlesEB    : " << nParticlesEB     << "; particlesSumPtEB    : " << particlesSumPtEB     << "; particles_pt / reco_pt: " << particlesSumPtEB/Photon_pt     << endl;
-	    cout << "nPhoEB          : " << nPhoEB           << "; phoPtSumEB          : " << phoPtSumEB           << "; photons_pt / reco_pt  : " << phoPtSumEB/Photon_pt           << endl;
-	    cout << "nMatchSiblingsEB: " << nMatchSiblingsEB << "; matchSiblingsSumPtEB: " << matchSiblingsSumPtEB << "; siblings_pt / reco_pt : " << matchSiblingsSumPtEB/Photon_pt << endl;
-	    cout << "Number distinct mothers: " << distinct_moms_EB.size() << endl;
-	    cout << "Distinct mother list: ";
+	    std::cout << "nParticlesEB    : " << nParticlesEB     << "; particlesSumPtEB    : " << particlesSumPtEB     << "; particles_pt / reco_pt: " << particlesSumPtEB/Photon_pt     << std::endl;
+	    std::cout << "nPhoEB          : " << nPhoEB           << "; phoPtSumEB          : " << phoPtSumEB           << "; photons_pt / reco_pt  : " << phoPtSumEB/Photon_pt           << std::endl;
+	    std::cout << "nMatchSiblingsEB: " << nMatchSiblingsEB << "; matchSiblingsSumPtEB: " << matchSiblingsSumPtEB << "; siblings_pt / reco_pt : " << matchSiblingsSumPtEB/Photon_pt << std::endl;
+	    std::cout << "Number distinct mothers: " << distinct_moms_EB.size() << std::endl;
+	    std::cout << "Distinct mother list: ";
 	    for (std::vector<std::pair<int, double> >::iterator it = distinct_moms_EB.begin(); it != distinct_moms_EB.end(); ++it) {
-	      cout << "(" << it->first << "," << it->second << ")";
-	      if (std::next(it,1) != distinct_moms_EB.end()) cout << ", ";
+	      std::cout << "(" << it->first << "," << it->second << ")";
+	      if (std::next(it,1) != distinct_moms_EB.end()) std::cout << ", ";
 	    }
-	    cout << endl;
+	    std::cout << std::endl;
 	  }
 	  if (distinct_moms_EB.size() == 1) {
 	    sieie_one_mother_EB->Fill(Photon_sigmaIetaIeta5x5,Event_weightAll);
@@ -871,13 +880,13 @@ void MCFakeRateClosureTestWithFakes::Loop()
 	  if (Photon_passSieie) gen_photon_reco_photon_pt_diff_EE_passSieie->Fill( PhotonGenMatch_pt/Photon_pt,Event_weightAll );
 	  if (!Photon_passSieie) gen_photon_reco_photon_pt_diff_EE_failSieie->Fill( PhotonGenMatch_pt/Photon_pt,Event_weightAll );
 	  if (printdRConInfo) {
-	    cout << endl;
-	    cout << "Run: " << Event_run << ", LS: " << Event_LS << ", event number: " << Event_evnum << ", weight = " << Event_weightAll <<  endl;
-	    cout << "EE; final state (status 1); dR <= 0.1; numerator (no sieie cut)" << endl;
-	    cout << "Reco photon: pt = " << Photon_pt << "; sc_eta = " << Photon_scEta << "; eta = " << Photon_eta << "; phi = " << Photon_phi << "; sieie = " << Photon_sigmaIetaIeta5x5
-		 << "; isSaturated = " << Photon_isSaturated << "; passSieie = " << Photon_passSieie << endl;
-	    cout << "Photon gen match: pt = " << PhotonGenMatch_pt << "; eta = " << PhotonGenMatch_eta << "; phi = " << PhotonGenMatch_phi << endl;
-	    cout << "gen_pt / reco_pt: " << PhotonGenMatch_pt/Photon_pt << endl;
+	    std::cout << std::endl;
+	    std::cout << "Run: " << Event_run << ", LS: " << Event_LS << ", event number: " << Event_evnum << ", weight = " << Event_weightAll <<  std::endl;
+	    std::cout << "EE; final state (status 1); dR <= 0.1; numerator (no sieie cut)" << std::endl;
+	    std::cout << "Reco photon: pt = " << Photon_pt << "; sc_eta = " << Photon_scEta << "; eta = " << Photon_eta << "; phi = " << Photon_phi << "; sieie = " << Photon_sigmaIetaIeta5x5
+		 << "; isSaturated = " << Photon_isSaturated << "; passSieie = " << Photon_passSieie << std::endl;
+	    std::cout << "Photon gen match: pt = " << PhotonGenMatch_pt << "; eta = " << PhotonGenMatch_eta << "; phi = " << PhotonGenMatch_phi << std::endl;
+	    std::cout << "gen_pt / reco_pt: " << PhotonGenMatch_pt/Photon_pt << std::endl;
 	  }
 	  int nParticlesEE = GenMatchPt->size();
 	  double particlesSumPtEE = 0;
@@ -895,10 +904,10 @@ void MCFakeRateClosureTestWithFakes::Loop()
 	    if (add_first_element_EE) distinct_moms_EE.push_back(std::make_pair(GenMatchMotherPdgId->at(pos),GenMatchMotherPt->at(pos)));
 	    add_first_element_EE = false;
 	    if (printdRConInfo) {
-	      cout << "Particle " << pos << ": pdgId: " << GenMatchPdgId->at(pos) << "; pt: " << GenMatchPt->at(pos)
+	      std::cout << "Particle " << pos << ": pdgId: " << GenMatchPdgId->at(pos) << "; pt: " << GenMatchPt->at(pos)
 		   << "; eta: " << GenMatchEta->at(pos) << "; phi: " << GenMatchPhi->at(pos) << "; dR: " << GenMatchDeltaR->at(pos)
 		   << "; nMothers: " << GenMatchNumMothers->at(pos) << "; mother pdgId: " << GenMatchMotherPdgId->at(pos)
-		   << "; mother pt: " << GenMatchMotherPt->at(pos) << "; mother status: " << GenMatchMotherStatus->at(pos) << endl;
+		   << "; mother pt: " << GenMatchMotherPt->at(pos) << "; mother status: " << GenMatchMotherStatus->at(pos) << std::endl;
 	    }
 	    for (std::vector<std::pair<int, double> >::iterator it = distinct_moms_EE.begin(); it != distinct_moms_EE.end(); ++it) {
 	      if (it->first == GenMatchMotherPdgId->at(pos) && it->second == GenMatchMotherPt->at(pos)) {
@@ -923,16 +932,16 @@ void MCFakeRateClosureTestWithFakes::Loop()
 	    }
 	  } // end loop through final state particles in dR cone
 	  if (printdRConInfo) {
-	    cout << "nParticlesEE    : " << nParticlesEE     << "; particlesSumPtEE    : " << particlesSumPtEE     << "; particles_pt / reco_pt: " << particlesSumPtEE/Photon_pt     << endl;
-	    cout << "nPhoEE          : " << nPhoEE           << "; phoPtSumEE          : " << phoPtSumEE           << "; photons_pt / reco_pt  : " << phoPtSumEE/Photon_pt           << endl;
-	    cout << "nMatchSiblingsEE: " << nMatchSiblingsEE << "; matchSiblingsSumPtEE: " << matchSiblingsSumPtEE << "; siblings_pt / reco_pt : " << matchSiblingsSumPtEE/Photon_pt << endl;
-	    cout << "Number distinct mothers: " << distinct_moms_EE.size() << endl;
-	    cout << "Distinct mother list: ";
+	    std::cout << "nParticlesEE    : " << nParticlesEE     << "; particlesSumPtEE    : " << particlesSumPtEE     << "; particles_pt / reco_pt: " << particlesSumPtEE/Photon_pt     << std::endl;
+	    std::cout << "nPhoEE          : " << nPhoEE           << "; phoPtSumEE          : " << phoPtSumEE           << "; photons_pt / reco_pt  : " << phoPtSumEE/Photon_pt           << std::endl;
+	    std::cout << "nMatchSiblingsEE: " << nMatchSiblingsEE << "; matchSiblingsSumPtEE: " << matchSiblingsSumPtEE << "; siblings_pt / reco_pt : " << matchSiblingsSumPtEE/Photon_pt << std::endl;
+	    std::cout << "Number distinct mothers: " << distinct_moms_EE.size() << std::endl;
+	    std::cout << "Distinct mother list: ";
 	    for (std::vector<std::pair<int, double> >::iterator it = distinct_moms_EE.begin(); it != distinct_moms_EE.end(); ++it) {
-	      cout << "(" << it->first << "," << it->second << ")";
-	      if (std::next(it,1) != distinct_moms_EE.end()) cout << ", ";
+	      std::cout << "(" << it->first << "," << it->second << ")";
+	      if (std::next(it,1) != distinct_moms_EE.end()) std::cout << ", ";
 	    }
-	    cout << endl;
+	    std::cout << std::endl;
 	  }
 	  if (distinct_moms_EE.size() == 1) {
 	    sieie_one_mother_EE->Fill(Photon_sigmaIetaIeta5x5,Event_weightAll);
@@ -992,93 +1001,93 @@ void MCFakeRateClosureTestWithFakes::Loop()
     
   } // end loop over entries
   
-  cout << endl;
-  cout << "Not applying event or sample weights for these object numbers." << endl;
-  cout << endl;
-  cout << "Number of numerator objects (passing sipip cut): " << nEvents << endl;
-  cout << endl;
-  cout << "--------------------------------------EB------------------------------------------ " << endl;
-  cout << "Number of numerator objects              : " << nEvents_EB << endl;
-  cout << endl;
-  cout << "Number of final state photon matches     : " << nFinalStatePhotonMatch_EB << setw(2) << "(" << setprecision(2) << fixed << (nFinalStatePhotonMatch_EB*100./nEvents_EB) << "%)" << endl;
-  cout << "Number of final state non-photon matches : " << nFinalStateNonPhotonMatch_EB << setw(2) << "(" << setprecision(2) << fixed << (nFinalStateNonPhotonMatch_EB*100./nEvents_EB) << "%)" << endl;
-  cout << "Number of gen particle photon matches    : " << nGenParticlePhotonMatch_EB << setw(2) << "(" << setprecision(2) << fixed <<  (nGenParticlePhotonMatch_EB*100./nEvents_EB) << "%)" << endl;
-  cout << "Number of gen particle non-photon matches: " << nGenParticleNonPhotonMatch_EB << setw(2) << "(" << setprecision(2) << fixed << (nGenParticleNonPhotonMatch_EB*100./nEvents_EB) << "%)" << endl;
-  cout << "Number of no matches                     : " << nNoMatch_EB << setw(2) << "(" << setprecision(2) << fixed << (nNoMatch_EB*100./nEvents_EB) << "%)" << endl;
-  cout << "Sum of 5 match categories                : " << nFinalStatePhotonMatch_EB+nFinalStateNonPhotonMatch_EB+nGenParticlePhotonMatch_EB+nGenParticleNonPhotonMatch_EB+nNoMatch_EB << endl;
-  cout << endl;
-  cout << "Number of final state photon - hadron mothers                 : " << nFinalStatePhotonHadronMother_EB << endl;
-  cout << "      from quark jet                                          : " << nFinalStatePhotonHadronMother_fromQuark_EB << endl;
-  cout << "      from gluon jet                                          : " << nFinalStatePhotonHadronMother_fromGluon_EB << endl;
-  cout << "Number of final state photon - ISR from proton                : " << nFinalStatePhotonISRfromProton_EB << endl;
-  cout << "Number of final state photon - other photon radiation         : " << nFinalStateOtherPhotonRadiation_EB << endl;
-  cout << "Number of final state photon - fragmentation from gluon mother: " << nFinalStatePhotonGluonMotherPhotonFrag_EB << endl;
-  cout << "Number of final state photon - other photon fragmentation     : " << nFinalStatePhotonOtherPhotonFragmentation_EB << endl;
-  cout << "Number of final state photon - real template photon           : " << nFinalStatePhotonRealTemplate_EB << endl;
-  cout << "Number of final state photon - photon mother                  : " << nFinalStatePhotonMother_EB << endl;
-  cout << "Number of final state photon - no match                       : " << nFinalStatePhotonNoMatch_EB << endl;
-  cout << "Sum of 8 match types                                          : " << nFinalStatePhotonHadronMother_EB+nFinalStatePhotonISRfromProton_EB+nFinalStateOtherPhotonRadiation_EB+
-    nFinalStatePhotonOtherPhotonFragmentation_EB+nFinalStatePhotonGluonMotherPhotonFrag_EB+nFinalStatePhotonNoMatch_EB+nFinalStatePhotonRealTemplate_EB+nFinalStatePhotonMother_EB << endl;
-  cout << endl;
-  cout << "Number of final state non-photon - hadron mothers: " << nFinalStateNonPhotonHadronMother_EB << endl;
-  cout << "Number of final state non-photon - electron pairs: " << nFinalStateNonPhotonElectronPair_EB << endl;
-  cout << "Number of final state non-photon - no matches    : " << nFinalStateNonPhotonNoMatch_EB << endl;
-  cout << "Sum of 3 match types                             : " << nFinalStateNonPhotonHadronMother_EB+nFinalStateNonPhotonElectronPair_EB+nFinalStateNonPhotonNoMatch_EB << endl;
-  cout << endl;
-  cout << "Average number of daughters - hadron mother case     : " << nAveNumDaughtersHadronMother_EB/(double)nFinalStatePhotonHadronMother_EB << endl;
-  cout << "Average number of daughters - ISR from proton        : " << nAveNumDaughtersISRfromProton_EB/(double)nFinalStatePhotonISRfromProton_EB << endl;
-  cout << "Average number of daughters - other radiation        : " << nAveNumDaughtersOtherPhotonRadiation_EB/(double)nFinalStateOtherPhotonRadiation_EB << endl;
-  cout << "Average number of daughters - frag. from gluon mother: " << nAveNumDaughtersGluonMotherPhotonFrag_EB/(double)nFinalStatePhotonGluonMotherPhotonFrag_EB << endl;
-  cout << "Average number of daughters - other fragmentation    : " << nAveNumDaughtersOtherPhotonFragmentation_EB/(double)nFinalStatePhotonOtherPhotonFragmentation_EB << endl;
-  cout << "Average number of daughters - hard interacton photon : " << nAveNumDaughtersRealTemplatePhotons_EB/(double)nFinalStatePhotonRealTemplate_EB << endl;
-  cout << endl;
-  cout << "--------------------------------------EE------------------------------------------ " << endl;
-  cout << "Number of numerator objects              : " << nEvents_EE << endl;
-  cout << endl;
-  cout << "Number of final state photon matches     : " << nFinalStatePhotonMatch_EE << setw(2) << "(" << setprecision(2) << fixed << (nFinalStatePhotonMatch_EE*100./nEvents_EE) << "%)" << endl;
-  cout << "Number of final state non-photon matches : " << nFinalStateNonPhotonMatch_EE << setw(2) << "(" << setprecision(2) << fixed << (nFinalStateNonPhotonMatch_EE*100./nEvents_EE) << "%)" << endl;
-  cout << "Number of gen particle photon matches    : " << nGenParticlePhotonMatch_EE << setw(2) << "(" << setprecision(2) << fixed <<  (nGenParticlePhotonMatch_EE*100./nEvents_EE) << "%)" << endl;
-  cout << "Number of gen particle non-photon matches: " << nGenParticleNonPhotonMatch_EE << setw(2) << "(" << setprecision(2) << fixed << (nGenParticleNonPhotonMatch_EE*100./nEvents_EE) << "%)" << endl;
-  cout << "Number of no matches                     : " << nNoMatch_EE << setw(2) << "(" << setprecision(2) << fixed << (nNoMatch_EE*100./nEvents_EE) << "%)" << endl;
-  cout << "Sum of 5 match categories                : " << nFinalStatePhotonMatch_EE+nFinalStateNonPhotonMatch_EE+nGenParticlePhotonMatch_EE+nGenParticleNonPhotonMatch_EE+nNoMatch_EE << endl;
-  cout << endl;
-  cout << "Number of final state photon - hadron mothers                 : " << nFinalStatePhotonHadronMother_EE << endl;
-  cout << "      from quark jet                                          : " << nFinalStatePhotonHadronMother_fromQuark_EE << endl;
-  cout << "      from gluon jet                                          : " << nFinalStatePhotonHadronMother_fromGluon_EE << endl;
-  cout << "Number of final state photon - ISR from proton                : " << nFinalStatePhotonISRfromProton_EE << endl;
-  cout << "Number of final state photon - other photon radiation         : " << nFinalStateOtherPhotonRadiation_EE << endl;
-  cout << "Number of final state photon - fragmentation from gluon mother: " << nFinalStatePhotonGluonMotherPhotonFrag_EE << endl;
-  cout << "Number of final state photon - other photon fragmentation     : " << nFinalStatePhotonOtherPhotonFragmentation_EE << endl;
-  cout << "Number of final state photon - real template photon           : " << nFinalStatePhotonRealTemplate_EE << endl;
-  cout << "Number of final state photon - photon mother                  : " << nFinalStatePhotonMother_EE << endl;
-  cout << "Number of final state photon - no match                       : " << nFinalStatePhotonNoMatch_EE << endl;
-  cout << "Sum of 8 match types                                          : " << nFinalStatePhotonHadronMother_EE+nFinalStatePhotonISRfromProton_EE+nFinalStateOtherPhotonRadiation_EE+
-    nFinalStatePhotonOtherPhotonFragmentation_EE+nFinalStatePhotonGluonMotherPhotonFrag_EE+nFinalStatePhotonNoMatch_EE+nFinalStatePhotonRealTemplate_EE+nFinalStatePhotonMother_EE << endl;
-  cout << endl;
-  cout << "Number of final state non-photon - hadron mothers: " << nFinalStateNonPhotonHadronMother_EE << endl;
-  cout << "Number of final state non-photon - electron pairs: " << nFinalStateNonPhotonElectronPair_EE << endl;
-  cout << "Number of final state non-photon - no matches    : " << nFinalStateNonPhotonNoMatch_EE << endl;
-  cout << "Sum of 3 match types                             : " << nFinalStateNonPhotonHadronMother_EE+nFinalStateNonPhotonElectronPair_EE+nFinalStateNonPhotonNoMatch_EE << endl;
-  cout << endl;
-  cout << "Average number of daughters - hadron mother case     : " << nAveNumDaughtersHadronMother_EE/(double)nFinalStatePhotonHadronMother_EE << endl;
-  cout << "Average number of daughters - ISR from proton        : " << nAveNumDaughtersISRfromProton_EE/(double)nFinalStatePhotonISRfromProton_EE << endl;
-  cout << "Average number of daughters - other radiation        : " << nAveNumDaughtersOtherPhotonRadiation_EE/(double)nFinalStateOtherPhotonRadiation_EE << endl;
-  cout << "Average number of daughters - frag. from gluon mother: " << nAveNumDaughtersGluonMotherPhotonFrag_EE/(double)nFinalStatePhotonGluonMotherPhotonFrag_EE << endl;
-  cout << "Average number of daughters - other fragmentation    : " << nAveNumDaughtersOtherPhotonFragmentation_EE/(double)nFinalStatePhotonOtherPhotonFragmentation_EE << endl;
-  cout << "Average number of daughters - hard interacton photon : " << nAveNumDaughtersRealTemplatePhotons_EE/(double)nFinalStatePhotonRealTemplate_EE << endl;
-  cout << endl;
+  std::cout << std::endl;
+  std::cout << "Not applying event or sample weights for these object numbers." << std::endl;
+  std::cout << std::endl;
+  std::cout << "Number of numerator objects (passing sipip cut): " << nEvents << std::endl;
+  std::cout << std::endl;
+  std::cout << "--------------------------------------EB------------------------------------------ " << std::endl;
+  std::cout << "Number of numerator objects              : " << nEvents_EB << std::endl;
+  std::cout << std::endl;
+  std::cout << "Number of final state photon matches     : " << nFinalStatePhotonMatch_EB << std::setw(2) << "(" << std::setprecision(2) << std::fixed << (nFinalStatePhotonMatch_EB*100./nEvents_EB) << "%)" << std::endl;
+  std::cout << "Number of final state non-photon matches : " << nFinalStateNonPhotonMatch_EB << std::setw(2) << "(" << std::setprecision(2) << std::fixed << (nFinalStateNonPhotonMatch_EB*100./nEvents_EB) << "%)" << std::endl;
+  std::cout << "Number of gen particle photon matches    : " << nGenParticlePhotonMatch_EB << std::setw(2) << "(" << std::setprecision(2) << std::fixed <<  (nGenParticlePhotonMatch_EB*100./nEvents_EB) << "%)" << std::endl;
+  std::cout << "Number of gen particle non-photon matches: " << nGenParticleNonPhotonMatch_EB << std::setw(2) << "(" << std::setprecision(2) << std::fixed << (nGenParticleNonPhotonMatch_EB*100./nEvents_EB) << "%)" << std::endl;
+  std::cout << "Number of no matches                     : " << nNoMatch_EB << std::setw(2) << "(" << std::setprecision(2) << std::fixed << (nNoMatch_EB*100./nEvents_EB) << "%)" << std::endl;
+  std::cout << "Sum of 5 match categories                : " << nFinalStatePhotonMatch_EB+nFinalStateNonPhotonMatch_EB+nGenParticlePhotonMatch_EB+nGenParticleNonPhotonMatch_EB+nNoMatch_EB << std::endl;
+  std::cout << std::endl;
+  std::cout << "Number of final state photon - hadron mothers                 : " << nFinalStatePhotonHadronMother_EB << std::endl;
+  std::cout << "      from quark jet                                          : " << nFinalStatePhotonHadronMother_fromQuark_EB << std::endl;
+  std::cout << "      from gluon jet                                          : " << nFinalStatePhotonHadronMother_fromGluon_EB << std::endl;
+  std::cout << "Number of final state photon - ISR from proton                : " << nFinalStatePhotonISRfromProton_EB << std::endl;
+  std::cout << "Number of final state photon - other photon radiation         : " << nFinalStateOtherPhotonRadiation_EB << std::endl;
+  std::cout << "Number of final state photon - fragmentation from gluon mother: " << nFinalStatePhotonGluonMotherPhotonFrag_EB << std::endl;
+  std::cout << "Number of final state photon - other photon fragmentation     : " << nFinalStatePhotonOtherPhotonFragmentation_EB << std::endl;
+  std::cout << "Number of final state photon - real template photon           : " << nFinalStatePhotonRealTemplate_EB << std::endl;
+  std::cout << "Number of final state photon - photon mother                  : " << nFinalStatePhotonMother_EB << std::endl;
+  std::cout << "Number of final state photon - no match                       : " << nFinalStatePhotonNoMatch_EB << std::endl;
+  std::cout << "Sum of 8 match types                                          : " << nFinalStatePhotonHadronMother_EB+nFinalStatePhotonISRfromProton_EB+nFinalStateOtherPhotonRadiation_EB+
+    nFinalStatePhotonOtherPhotonFragmentation_EB+nFinalStatePhotonGluonMotherPhotonFrag_EB+nFinalStatePhotonNoMatch_EB+nFinalStatePhotonRealTemplate_EB+nFinalStatePhotonMother_EB << std::endl;
+  std::cout << std::endl;
+  std::cout << "Number of final state non-photon - hadron mothers: " << nFinalStateNonPhotonHadronMother_EB << std::endl;
+  std::cout << "Number of final state non-photon - electron pairs: " << nFinalStateNonPhotonElectronPair_EB << std::endl;
+  std::cout << "Number of final state non-photon - no matches    : " << nFinalStateNonPhotonNoMatch_EB << std::endl;
+  std::cout << "Sum of 3 match types                             : " << nFinalStateNonPhotonHadronMother_EB+nFinalStateNonPhotonElectronPair_EB+nFinalStateNonPhotonNoMatch_EB << std::endl;
+  std::cout << std::endl;
+  std::cout << "Average number of daughters - hadron mother case     : " << nAveNumDaughtersHadronMother_EB/(double)nFinalStatePhotonHadronMother_EB << std::endl;
+  std::cout << "Average number of daughters - ISR from proton        : " << nAveNumDaughtersISRfromProton_EB/(double)nFinalStatePhotonISRfromProton_EB << std::endl;
+  std::cout << "Average number of daughters - other radiation        : " << nAveNumDaughtersOtherPhotonRadiation_EB/(double)nFinalStateOtherPhotonRadiation_EB << std::endl;
+  std::cout << "Average number of daughters - frag. from gluon mother: " << nAveNumDaughtersGluonMotherPhotonFrag_EB/(double)nFinalStatePhotonGluonMotherPhotonFrag_EB << std::endl;
+  std::cout << "Average number of daughters - other fragmentation    : " << nAveNumDaughtersOtherPhotonFragmentation_EB/(double)nFinalStatePhotonOtherPhotonFragmentation_EB << std::endl;
+  std::cout << "Average number of daughters - hard interacton photon : " << nAveNumDaughtersRealTemplatePhotons_EB/(double)nFinalStatePhotonRealTemplate_EB << std::endl;
+  std::cout << std::endl;
+  std::cout << "--------------------------------------EE------------------------------------------ " << std::endl;
+  std::cout << "Number of numerator objects              : " << nEvents_EE << std::endl;
+  std::cout << std::endl;
+  std::cout << "Number of final state photon matches     : " << nFinalStatePhotonMatch_EE << std::setw(2) << "(" << std::setprecision(2) << std::fixed << (nFinalStatePhotonMatch_EE*100./nEvents_EE) << "%)" << std::endl;
+  std::cout << "Number of final state non-photon matches : " << nFinalStateNonPhotonMatch_EE << std::setw(2) << "(" << std::setprecision(2) << std::fixed << (nFinalStateNonPhotonMatch_EE*100./nEvents_EE) << "%)" << std::endl;
+  std::cout << "Number of gen particle photon matches    : " << nGenParticlePhotonMatch_EE << std::setw(2) << "(" << std::setprecision(2) << std::fixed <<  (nGenParticlePhotonMatch_EE*100./nEvents_EE) << "%)" << std::endl;
+  std::cout << "Number of gen particle non-photon matches: " << nGenParticleNonPhotonMatch_EE << std::setw(2) << "(" << std::setprecision(2) << std::fixed << (nGenParticleNonPhotonMatch_EE*100./nEvents_EE) << "%)" << std::endl;
+  std::cout << "Number of no matches                     : " << nNoMatch_EE << std::setw(2) << "(" << std::setprecision(2) << std::fixed << (nNoMatch_EE*100./nEvents_EE) << "%)" << std::endl;
+  std::cout << "Sum of 5 match categories                : " << nFinalStatePhotonMatch_EE+nFinalStateNonPhotonMatch_EE+nGenParticlePhotonMatch_EE+nGenParticleNonPhotonMatch_EE+nNoMatch_EE << std::endl;
+  std::cout << std::endl;
+  std::cout << "Number of final state photon - hadron mothers                 : " << nFinalStatePhotonHadronMother_EE << std::endl;
+  std::cout << "      from quark jet                                          : " << nFinalStatePhotonHadronMother_fromQuark_EE << std::endl;
+  std::cout << "      from gluon jet                                          : " << nFinalStatePhotonHadronMother_fromGluon_EE << std::endl;
+  std::cout << "Number of final state photon - ISR from proton                : " << nFinalStatePhotonISRfromProton_EE << std::endl;
+  std::cout << "Number of final state photon - other photon radiation         : " << nFinalStateOtherPhotonRadiation_EE << std::endl;
+  std::cout << "Number of final state photon - fragmentation from gluon mother: " << nFinalStatePhotonGluonMotherPhotonFrag_EE << std::endl;
+  std::cout << "Number of final state photon - other photon fragmentation     : " << nFinalStatePhotonOtherPhotonFragmentation_EE << std::endl;
+  std::cout << "Number of final state photon - real template photon           : " << nFinalStatePhotonRealTemplate_EE << std::endl;
+  std::cout << "Number of final state photon - photon mother                  : " << nFinalStatePhotonMother_EE << std::endl;
+  std::cout << "Number of final state photon - no match                       : " << nFinalStatePhotonNoMatch_EE << std::endl;
+  std::cout << "Sum of 8 match types                                          : " << nFinalStatePhotonHadronMother_EE+nFinalStatePhotonISRfromProton_EE+nFinalStateOtherPhotonRadiation_EE+
+    nFinalStatePhotonOtherPhotonFragmentation_EE+nFinalStatePhotonGluonMotherPhotonFrag_EE+nFinalStatePhotonNoMatch_EE+nFinalStatePhotonRealTemplate_EE+nFinalStatePhotonMother_EE << std::endl;
+  std::cout << std::endl;
+  std::cout << "Number of final state non-photon - hadron mothers: " << nFinalStateNonPhotonHadronMother_EE << std::endl;
+  std::cout << "Number of final state non-photon - electron pairs: " << nFinalStateNonPhotonElectronPair_EE << std::endl;
+  std::cout << "Number of final state non-photon - no matches    : " << nFinalStateNonPhotonNoMatch_EE << std::endl;
+  std::cout << "Sum of 3 match types                             : " << nFinalStateNonPhotonHadronMother_EE+nFinalStateNonPhotonElectronPair_EE+nFinalStateNonPhotonNoMatch_EE << std::endl;
+  std::cout << std::endl;
+  std::cout << "Average number of daughters - hadron mother case     : " << nAveNumDaughtersHadronMother_EE/(double)nFinalStatePhotonHadronMother_EE << std::endl;
+  std::cout << "Average number of daughters - ISR from proton        : " << nAveNumDaughtersISRfromProton_EE/(double)nFinalStatePhotonISRfromProton_EE << std::endl;
+  std::cout << "Average number of daughters - other radiation        : " << nAveNumDaughtersOtherPhotonRadiation_EE/(double)nFinalStateOtherPhotonRadiation_EE << std::endl;
+  std::cout << "Average number of daughters - frag. from gluon mother: " << nAveNumDaughtersGluonMotherPhotonFrag_EE/(double)nFinalStatePhotonGluonMotherPhotonFrag_EE << std::endl;
+  std::cout << "Average number of daughters - other fragmentation    : " << nAveNumDaughtersOtherPhotonFragmentation_EE/(double)nFinalStatePhotonOtherPhotonFragmentation_EE << std::endl;
+  std::cout << "Average number of daughters - hard interacton photon : " << nAveNumDaughtersRealTemplatePhotons_EE/(double)nFinalStatePhotonRealTemplate_EE << std::endl;
+  std::cout << std::endl;
   
-  cout << endl;
-  cout << "Fakes are all hadron mother matches passing the high pt photon ID." << endl;
-  cout << "--------------------------------------EB------------------------------------------ " << endl;
-  cout << "Number of fakes      : " << nFakesEB << endl;
-  cout << "Number of quark fakes: " << nQuarkFakesEB << endl;
-  cout << "Number of gluon fakes: " << nGluonFakesEB << endl;
-  cout << "--------------------------------------EE------------------------------------------ " << endl;
-  cout << "Number of fakes      : " << nFakesEE << endl;
-  cout << "Number of quark fakes: " << nQuarkFakesEE << endl;
-  cout << "Number of gluon fakes: " << nGluonFakesEE << endl;
-  cout << endl;
+  std::cout << std::endl;
+  std::cout << "Fakes are all hadron mother matches passing the high pt photon ID." << std::endl;
+  std::cout << "--------------------------------------EB------------------------------------------ " << std::endl;
+  std::cout << "Number of fakes      : " << nFakesEB << std::endl;
+  std::cout << "Number of quark fakes: " << nQuarkFakesEB << std::endl;
+  std::cout << "Number of gluon fakes: " << nGluonFakesEB << std::endl;
+  std::cout << "--------------------------------------EE------------------------------------------ " << std::endl;
+  std::cout << "Number of fakes      : " << nFakesEE << std::endl;
+  std::cout << "Number of quark fakes: " << nQuarkFakesEE << std::endl;
+  std::cout << "Number of gluon fakes: " << nGluonFakesEE << std::endl;
+  std::cout << std::endl;
   
   TFile file_out(filename,"RECREATE");
   
@@ -1184,54 +1193,54 @@ void MCFakeRateClosureTestWithFakes::Loop()
   // write fake distributions
   photon_fakes_sIeIe_EB->Write();
   photon_fakes_sIeIe_EE->Write();
-  cout << photon_fakes_sIeIe_EB->GetName() << "\t integral: " << photon_fakes_sIeIe_EB->Integral() << endl;
-  cout << photon_fakes_sIeIe_EE->GetName() << "\t integral: " << photon_fakes_sIeIe_EE->Integral() << endl;
+  std::cout << photon_fakes_sIeIe_EB->GetName() << "\t integral: " << photon_fakes_sIeIe_EB->Integral() << std::endl;
+  std::cout << photon_fakes_sIeIe_EE->GetName() << "\t integral: " << photon_fakes_sIeIe_EE->Integral() << std::endl;
   photon_fakes_pt_EB->Write();
   photon_fakes_pt_EE->Write();
-  cout << photon_fakes_pt_EB->GetName() << "\t integral: " << photon_fakes_pt_EB->Integral() << endl;
-  cout << photon_fakes_pt_EE->GetName() << "\t integral: " << photon_fakes_pt_EE->Integral() << endl;
+  std::cout << photon_fakes_pt_EB->GetName() << "\t integral: " << photon_fakes_pt_EB->Integral() << std::endl;
+  std::cout << photon_fakes_pt_EE->GetName() << "\t integral: " << photon_fakes_pt_EE->Integral() << std::endl;
   photon_fakes_eta_EB->Write();
   photon_fakes_eta_EE->Write();
-  cout << photon_fakes_eta_EB->GetName() << "\t integral: " << photon_fakes_eta_EB->Integral() << endl;
-  cout << photon_fakes_eta_EE->GetName() << "\t integral: " << photon_fakes_eta_EE->Integral() << endl;
+  std::cout << photon_fakes_eta_EB->GetName() << "\t integral: " << photon_fakes_eta_EB->Integral() << std::endl;
+  std::cout << photon_fakes_eta_EE->GetName() << "\t integral: " << photon_fakes_eta_EE->Integral() << std::endl;
   photon_fakes_phi_EB->Write();
   photon_fakes_phi_EE->Write();
-  cout << photon_fakes_phi_EB->GetName() << "\t integral: " << photon_fakes_phi_EB->Integral() << endl;
-  cout << photon_fakes_phi_EE->GetName() << "\t integral: " << photon_fakes_phi_EE->Integral() << endl;
+  std::cout << photon_fakes_phi_EB->GetName() << "\t integral: " << photon_fakes_phi_EB->Integral() << std::endl;
+  std::cout << photon_fakes_phi_EE->GetName() << "\t integral: " << photon_fakes_phi_EE->Integral() << std::endl;
   // write quark fake distributions
   photon_quark_fakes_sIeIe_EB->Write();
   photon_quark_fakes_sIeIe_EE->Write();
-  cout << photon_quark_fakes_sIeIe_EB->GetName() << "\t integral: " << photon_quark_fakes_sIeIe_EB->Integral() << endl;
-  cout << photon_quark_fakes_sIeIe_EE->GetName() << "\t integral: " << photon_quark_fakes_sIeIe_EE->Integral() << endl;
+  std::cout << photon_quark_fakes_sIeIe_EB->GetName() << "\t integral: " << photon_quark_fakes_sIeIe_EB->Integral() << std::endl;
+  std::cout << photon_quark_fakes_sIeIe_EE->GetName() << "\t integral: " << photon_quark_fakes_sIeIe_EE->Integral() << std::endl;
   photon_quark_fakes_pt_EB->Write();
   photon_quark_fakes_pt_EE->Write();
-  cout << photon_quark_fakes_pt_EB->GetName() << "\t integral: " << photon_quark_fakes_pt_EB->Integral() << endl;
-  cout << photon_quark_fakes_pt_EE->GetName() << "\t integral: " << photon_quark_fakes_pt_EE->Integral() << endl;
+  std::cout << photon_quark_fakes_pt_EB->GetName() << "\t integral: " << photon_quark_fakes_pt_EB->Integral() << std::endl;
+  std::cout << photon_quark_fakes_pt_EE->GetName() << "\t integral: " << photon_quark_fakes_pt_EE->Integral() << std::endl;
   photon_quark_fakes_eta_EB->Write();
   photon_quark_fakes_eta_EE->Write();
-  cout << photon_quark_fakes_eta_EB->GetName() << "\t integral: " << photon_quark_fakes_eta_EB->Integral() << endl;
-  cout << photon_quark_fakes_eta_EE->GetName() << "\t integral: " << photon_quark_fakes_eta_EE->Integral() << endl;
+  std::cout << photon_quark_fakes_eta_EB->GetName() << "\t integral: " << photon_quark_fakes_eta_EB->Integral() << std::endl;
+  std::cout << photon_quark_fakes_eta_EE->GetName() << "\t integral: " << photon_quark_fakes_eta_EE->Integral() << std::endl;
   photon_quark_fakes_phi_EB->Write();
   photon_quark_fakes_phi_EE->Write();
-  cout << photon_quark_fakes_phi_EB->GetName() << "\t integral: " << photon_quark_fakes_phi_EB->Integral() << endl;
-  cout << photon_quark_fakes_phi_EE->GetName() << "\t integral: " << photon_quark_fakes_phi_EE->Integral() << endl;
+  std::cout << photon_quark_fakes_phi_EB->GetName() << "\t integral: " << photon_quark_fakes_phi_EB->Integral() << std::endl;
+  std::cout << photon_quark_fakes_phi_EE->GetName() << "\t integral: " << photon_quark_fakes_phi_EE->Integral() << std::endl;
   // write gluon fake distributions
   photon_gluon_fakes_sIeIe_EB->Write();
   photon_gluon_fakes_sIeIe_EE->Write();
-  cout << photon_gluon_fakes_sIeIe_EB->GetName() << "\t integral: " << photon_gluon_fakes_sIeIe_EB->Integral() << endl;
-  cout << photon_gluon_fakes_sIeIe_EE->GetName() << "\t integral: " << photon_gluon_fakes_sIeIe_EE->Integral() << endl;
+  std::cout << photon_gluon_fakes_sIeIe_EB->GetName() << "\t integral: " << photon_gluon_fakes_sIeIe_EB->Integral() << std::endl;
+  std::cout << photon_gluon_fakes_sIeIe_EE->GetName() << "\t integral: " << photon_gluon_fakes_sIeIe_EE->Integral() << std::endl;
   photon_gluon_fakes_pt_EB->Write();
   photon_gluon_fakes_pt_EE->Write();
-  cout << photon_gluon_fakes_pt_EB->GetName() << "\t integral: " << photon_gluon_fakes_pt_EB->Integral() << endl;
-  cout << photon_gluon_fakes_pt_EE->GetName() << "\t integral: " << photon_gluon_fakes_pt_EE->Integral() << endl;
+  std::cout << photon_gluon_fakes_pt_EB->GetName() << "\t integral: " << photon_gluon_fakes_pt_EB->Integral() << std::endl;
+  std::cout << photon_gluon_fakes_pt_EE->GetName() << "\t integral: " << photon_gluon_fakes_pt_EE->Integral() << std::endl;
   photon_gluon_fakes_eta_EB->Write();
   photon_gluon_fakes_eta_EE->Write();
-  cout << photon_gluon_fakes_eta_EB->GetName() << "\t integral: " << photon_gluon_fakes_eta_EB->Integral() << endl;
-  cout << photon_gluon_fakes_eta_EE->GetName() << "\t integral: " << photon_gluon_fakes_eta_EE->Integral() << endl;
+  std::cout << photon_gluon_fakes_eta_EB->GetName() << "\t integral: " << photon_gluon_fakes_eta_EB->Integral() << std::endl;
+  std::cout << photon_gluon_fakes_eta_EE->GetName() << "\t integral: " << photon_gluon_fakes_eta_EE->Integral() << std::endl;
   photon_gluon_fakes_phi_EB->Write();
   photon_gluon_fakes_phi_EE->Write();
-  cout << photon_gluon_fakes_phi_EB->GetName() << "\t integral: " << photon_gluon_fakes_phi_EB->Integral() << endl;
-  cout << photon_gluon_fakes_phi_EE->GetName() << "\t integral: " << photon_gluon_fakes_phi_EE->Integral() << endl;
+  std::cout << photon_gluon_fakes_phi_EB->GetName() << "\t integral: " << photon_gluon_fakes_phi_EB->Integral() << std::endl;
+  std::cout << photon_gluon_fakes_phi_EE->GetName() << "\t integral: " << photon_gluon_fakes_phi_EE->Integral() << std::endl;
   
   // write passHighPtID histograms
   phoPtEB_passHighPtID_varbin.Write();
@@ -1243,119 +1252,119 @@ void MCFakeRateClosureTestWithFakes::Loop()
   
 
   double bin_sum_EB = 0;
-  cout << phoPtEB_passHighPtID_varbin.GetName() << "\t integral: " << phoPtEB_passHighPtID_varbin.Integral() << endl;
+  std::cout << phoPtEB_passHighPtID_varbin.GetName() << "\t integral: " << phoPtEB_passHighPtID_varbin.Integral() << std::endl;
   for (int i = 1; i < phoPtEB_passHighPtID_varbin.GetSize()-1; i++) {
-    cout << phoPtEB_passHighPtID_varbin.GetName()
+    std::cout << phoPtEB_passHighPtID_varbin.GetName()
 	 << " bin "
 	 << phoPtEB_passHighPtID_varbin.GetBin(i)
 	 << " content: "
 	 << phoPtEB_passHighPtID_varbin.GetBinContent(i)
-	 << endl;
+	 << std::endl;
     bin_sum_EB = bin_sum_EB + phoPtEB_passHighPtID_varbin.GetBinContent(i);
   }
-  cout << phoPtEB_passHighPtID_varbin.GetName() << " bin sum: " << bin_sum_EB << endl;
+  std::cout << phoPtEB_passHighPtID_varbin.GetName() << " bin sum: " << bin_sum_EB << std::endl;
   
   double bin_sum_EE = 0;
-  cout << phoPtEE_passHighPtID_varbin.GetName() << "\t integral: " << phoPtEE_passHighPtID_varbin.Integral() << endl;
+  std::cout << phoPtEE_passHighPtID_varbin.GetName() << "\t integral: " << phoPtEE_passHighPtID_varbin.Integral() << std::endl;
   for (int i = 1; i < phoPtEB_passHighPtID_varbin.GetSize()-1; i++) {  
-    cout << phoPtEE_passHighPtID_varbin.GetName()
+    std::cout << phoPtEE_passHighPtID_varbin.GetName()
 	 << " bin "
 	 << phoPtEE_passHighPtID_varbin.GetBin(i)
 	 << " content: "
 	 << phoPtEE_passHighPtID_varbin.GetBinContent(i)
-	 << endl;
+	 << std::endl;
     bin_sum_EE = bin_sum_EE + phoPtEE_passHighPtID_varbin.GetBinContent(i);
   }
-  cout << phoPtEB_passHighPtID_varbin.GetName() << " bin sum: " << bin_sum_EE << endl;
+  std::cout << phoPtEB_passHighPtID_varbin.GetName() << " bin sum: " << bin_sum_EE << std::endl;
   
   // write numerator histograms from mc truth fakes
-  for (vector<TH1D*>::iterator it = sIeIeNumeratorEB_fromFakes.begin() ; it != sIeIeNumeratorEB_fromFakes.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = sIeIeNumeratorEB_fromFakes.begin() ; it != sIeIeNumeratorEB_fromFakes.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = sIeIeNumeratorEE_fromFakes.begin() ; it != sIeIeNumeratorEE_fromFakes.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = sIeIeNumeratorEE_fromFakes.begin() ; it != sIeIeNumeratorEE_fromFakes.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = chIsoNumeratorEB_fromFakes.begin() ; it != chIsoNumeratorEB_fromFakes.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = chIsoNumeratorEB_fromFakes.begin() ; it != chIsoNumeratorEB_fromFakes.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = chIsoNumeratorEE_fromFakes.begin() ; it != chIsoNumeratorEE_fromFakes.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = chIsoNumeratorEE_fromFakes.begin() ; it != chIsoNumeratorEE_fromFakes.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
   // write other sieie numerator histograms
-  for (vector<TH1D*>::iterator it = sIeIeNumeratorEB_fromReal.begin() ; it != sIeIeNumeratorEB_fromReal.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = sIeIeNumeratorEB_fromReal.begin() ; it != sIeIeNumeratorEB_fromReal.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = sIeIeNumeratorEE_fromReal.begin() ; it != sIeIeNumeratorEE_fromReal.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = sIeIeNumeratorEE_fromReal.begin() ; it != sIeIeNumeratorEE_fromReal.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = sIeIeNumeratorEB_fromPhotonHadronMother.begin() ; it != sIeIeNumeratorEB_fromPhotonHadronMother.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = sIeIeNumeratorEB_fromPhotonHadronMother.begin() ; it != sIeIeNumeratorEB_fromPhotonHadronMother.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = sIeIeNumeratorEE_fromPhotonHadronMother.begin() ; it != sIeIeNumeratorEE_fromPhotonHadronMother.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = sIeIeNumeratorEE_fromPhotonHadronMother.begin() ; it != sIeIeNumeratorEE_fromPhotonHadronMother.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = sIeIeNumeratorEB_fromPhotonISRfromProton.begin() ; it != sIeIeNumeratorEB_fromPhotonISRfromProton.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = sIeIeNumeratorEB_fromPhotonISRfromProton.begin() ; it != sIeIeNumeratorEB_fromPhotonISRfromProton.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = sIeIeNumeratorEE_fromPhotonISRfromProton.begin() ; it != sIeIeNumeratorEE_fromPhotonISRfromProton.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = sIeIeNumeratorEE_fromPhotonISRfromProton.begin() ; it != sIeIeNumeratorEE_fromPhotonISRfromProton.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = sIeIeNumeratorEB_fromOtherPhotonRadiation.begin() ; it != sIeIeNumeratorEB_fromOtherPhotonRadiation.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = sIeIeNumeratorEB_fromOtherPhotonRadiation.begin() ; it != sIeIeNumeratorEB_fromOtherPhotonRadiation.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = sIeIeNumeratorEE_fromOtherPhotonRadiation.begin() ; it != sIeIeNumeratorEE_fromOtherPhotonRadiation.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = sIeIeNumeratorEE_fromOtherPhotonRadiation.begin() ; it != sIeIeNumeratorEE_fromOtherPhotonRadiation.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = sIeIeNumeratorEB_fromGluonMotherPhotonFrag.begin() ; it != sIeIeNumeratorEB_fromGluonMotherPhotonFrag.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = sIeIeNumeratorEB_fromGluonMotherPhotonFrag.begin() ; it != sIeIeNumeratorEB_fromGluonMotherPhotonFrag.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = sIeIeNumeratorEE_fromGluonMotherPhotonFrag.begin() ; it != sIeIeNumeratorEE_fromGluonMotherPhotonFrag.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = sIeIeNumeratorEE_fromGluonMotherPhotonFrag.begin() ; it != sIeIeNumeratorEE_fromGluonMotherPhotonFrag.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = sIeIeNumeratorEB_fromOtherPhotonFragmentation.begin() ; it != sIeIeNumeratorEB_fromOtherPhotonFragmentation.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = sIeIeNumeratorEB_fromOtherPhotonFragmentation.begin() ; it != sIeIeNumeratorEB_fromOtherPhotonFragmentation.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = sIeIeNumeratorEE_fromOtherPhotonFragmentation.begin() ; it != sIeIeNumeratorEE_fromOtherPhotonFragmentation.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = sIeIeNumeratorEE_fromOtherPhotonFragmentation.begin() ; it != sIeIeNumeratorEE_fromOtherPhotonFragmentation.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = sIeIeNumeratorEB_fromNoMatch.begin() ; it != sIeIeNumeratorEB_fromNoMatch.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = sIeIeNumeratorEB_fromNoMatch.begin() ; it != sIeIeNumeratorEB_fromNoMatch.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = sIeIeNumeratorEE_fromNoMatch.begin() ; it != sIeIeNumeratorEE_fromNoMatch.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = sIeIeNumeratorEE_fromNoMatch.begin() ; it != sIeIeNumeratorEE_fromNoMatch.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = sIeIeNumeratorEB_fromNonPhotonMatch.begin() ; it != sIeIeNumeratorEB_fromNonPhotonMatch.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = sIeIeNumeratorEB_fromNonPhotonMatch.begin() ; it != sIeIeNumeratorEB_fromNonPhotonMatch.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = sIeIeNumeratorEE_fromNonPhotonMatch.begin() ; it != sIeIeNumeratorEE_fromNonPhotonMatch.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = sIeIeNumeratorEE_fromNonPhotonMatch.begin() ; it != sIeIeNumeratorEE_fromNonPhotonMatch.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = sIeIeNumeratorEB_fromGenParticleMatch.begin() ; it != sIeIeNumeratorEB_fromGenParticleMatch.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = sIeIeNumeratorEB_fromGenParticleMatch.begin() ; it != sIeIeNumeratorEB_fromGenParticleMatch.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
-  for (vector<TH1D*>::iterator it = sIeIeNumeratorEE_fromGenParticleMatch.begin() ; it != sIeIeNumeratorEE_fromGenParticleMatch.end(); ++it) {
-    cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << endl;
+  for (std::vector<TH1D*>::iterator it = sIeIeNumeratorEE_fromGenParticleMatch.begin() ; it != sIeIeNumeratorEE_fromGenParticleMatch.end(); ++it) {
+    std::cout << (*it)->GetName() << "\t integral: " << (*it)->Integral() << std::endl;
     (*it)->Write();
   }
   

--- a/FakeRateAnalysis/PhotonClosureTest/analysis/MCFakeRateClosureTestWithFakes.h
+++ b/FakeRateAnalysis/PhotonClosureTest/analysis/MCFakeRateClosureTestWithFakes.h
@@ -15,7 +15,7 @@
 // Header file for the classes stored in the TTree if any.
 #include "vector"
 
-class MCFakeRateClosureTestWithFakes {
+class MCFakeRateClosureTestWithFakesBase {
 public :
    TTree          *fChain;   //!pointer to the analyzed TTree or TChain
    Int_t           fCurrent; //!current Tree number in a TChain
@@ -979,18 +979,18 @@ public :
    Int_t           PhotonGenParent_pdgId;
    Int_t           PhotonGenParent_motherPdgId;
    Int_t           PhotonGenParent_grandmotherPdgId;
-   vector<double>  *GenMatchPt;
-   vector<double>  *GenMatchEta;
-   vector<double>  *GenMatchPhi;
-   vector<double>  *GenMatchPdgId;
-   vector<double>  *GenMatchDeltaR;
-   vector<double>  *GenMatchPtDiff;
-   vector<double>  *GenMatchNumMothers;
-   vector<double>  *GenMatchMotherPt;
-   vector<double>  *GenMatchMotherEta;
-   vector<double>  *GenMatchMotherPhi;
-   vector<double>  *GenMatchMotherStatus;
-   vector<double>  *GenMatchMotherPdgId;
+   std::vector<double>  *GenMatchPt;
+   std::vector<double>  *GenMatchEta;
+   std::vector<double>  *GenMatchPhi;
+   std::vector<double>  *GenMatchPdgId;
+   std::vector<double>  *GenMatchDeltaR;
+   std::vector<double>  *GenMatchPtDiff;
+   std::vector<double>  *GenMatchNumMothers;
+   std::vector<double>  *GenMatchMotherPt;
+   std::vector<double>  *GenMatchMotherEta;
+   std::vector<double>  *GenMatchMotherPhi;
+   std::vector<double>  *GenMatchMotherStatus;
+   std::vector<double>  *GenMatchMotherPdgId;
 
    // List of branches
    TBranch        *b_Event;   //!
@@ -1013,8 +1013,8 @@ public :
    TBranch        *b_GenMatchMotherStatus;   //!
    TBranch        *b_GenMatchMotherPdgId;   //!
 
-   MCFakeRateClosureTestWithFakes(TTree *tree=0);
-   virtual ~MCFakeRateClosureTestWithFakes();
+   MCFakeRateClosureTestWithFakesBase(TTree *tree=0);
+   virtual ~MCFakeRateClosureTestWithFakesBase();
    virtual Int_t    Cut(Long64_t entry);
    virtual Int_t    GetEntry(Long64_t entry);
    virtual Long64_t LoadTree(Long64_t entry);
@@ -1027,7 +1027,7 @@ public :
 #endif
 
 #ifdef MCFakeRateClosureTestWithFakes_cxx
-MCFakeRateClosureTestWithFakes::MCFakeRateClosureTestWithFakes(TTree *tree) : fChain(0) 
+MCFakeRateClosureTestWithFakesBase::MCFakeRateClosureTestWithFakesBase(TTree *tree) : fChain(0)
 {
 // if parameter tree is not specified (or zero), connect the file
 // used to generate this class and read the Tree.
@@ -1043,19 +1043,19 @@ MCFakeRateClosureTestWithFakes::MCFakeRateClosureTestWithFakes(TTree *tree) : fC
    Init(tree);
 }
 
-MCFakeRateClosureTestWithFakes::~MCFakeRateClosureTestWithFakes()
+MCFakeRateClosureTestWithFakesBase::~MCFakeRateClosureTestWithFakesBase()
 {
    if (!fChain) return;
    delete fChain->GetCurrentFile();
 }
 
-Int_t MCFakeRateClosureTestWithFakes::GetEntry(Long64_t entry)
+Int_t MCFakeRateClosureTestWithFakesBase::GetEntry(Long64_t entry)
 {
 // Read contents of entry.
    if (!fChain) return 0;
    return fChain->GetEntry(entry);
 }
-Long64_t MCFakeRateClosureTestWithFakes::LoadTree(Long64_t entry)
+Long64_t MCFakeRateClosureTestWithFakesBase::LoadTree(Long64_t entry)
 {
 // Set the environment to read one entry
    if (!fChain) return -5;
@@ -1068,7 +1068,7 @@ Long64_t MCFakeRateClosureTestWithFakes::LoadTree(Long64_t entry)
    return centry;
 }
 
-void MCFakeRateClosureTestWithFakes::Init(TTree *tree)
+void MCFakeRateClosureTestWithFakesBase::Init(TTree *tree)
 {
    // The Init() function is called when the selector needs to initialize
    // a new tree or chain. Typically here the branch addresses and branch
@@ -1119,7 +1119,7 @@ void MCFakeRateClosureTestWithFakes::Init(TTree *tree)
    Notify();
 }
 
-Bool_t MCFakeRateClosureTestWithFakes::Notify()
+Bool_t MCFakeRateClosureTestWithFakesBase::Notify()
 {
    // The Notify() function is called when a new file is opened. This
    // can be either for a new TTree in a TChain or when when a new TTree
@@ -1130,14 +1130,14 @@ Bool_t MCFakeRateClosureTestWithFakes::Notify()
    return kTRUE;
 }
 
-void MCFakeRateClosureTestWithFakes::Show(Long64_t entry)
+void MCFakeRateClosureTestWithFakesBase::Show(Long64_t entry)
 {
 // Print contents of entry.
 // If entry is not specified, print current entry
    if (!fChain) return;
    fChain->Show(entry);
 }
-Int_t MCFakeRateClosureTestWithFakes::Cut(Long64_t entry)
+Int_t MCFakeRateClosureTestWithFakesBase::Cut(Long64_t entry)
 {
 // This function may be called from Loop.
 // returns  1 if entry is accepted.

--- a/FakeRateAnalysis/PhotonClosureTest/scripts/diphoton_looper.C
+++ b/FakeRateAnalysis/PhotonClosureTest/scripts/diphoton_looper.C
@@ -6,32 +6,16 @@
 #include "TStopwatch.h"
 #include <iostream>
 
-#include "MCFakeRateClosureTest.C"
-#include "MCFakeRateClosureTestWithFakes.C"
+#include "diphoton-analysis/FakeRateAnalysis/PhotonClosureTest/analysis/MCFakeRateClosureTest.C"
+#include "diphoton-analysis/FakeRateAnalysis/PhotonClosureTest/analysis/MCFakeRateClosureTestWithFakes.C"
 
 using namespace std;
 
-void diphoton_looper() {
-  // input what sample to run on
-  TString sample = "";
-  cout << "Enter sample being run on (QCD, GJets, GGJets, or all): ";
-  cin >> sample;
-  if (sample != "QCD" && sample != "GJets" && sample != "GGJets" && sample != "all") {
-    cout << "Invalid choice!" << endl;
-    return;
-  }
+void diphoton_looper(TString run, TString sample, bool do_fakes) {
   cout << "\nUsing sample: " << sample << endl;
   
-  // choose what analysis class you want to use (run one at a time)
-  bool do_all = false;
-  bool do_fakes = true;
-  
-  if (!do_all && !do_fakes) {
-    cout << "Choose an analysis class to run on." << endl;
-    return;
-  }
-  if (do_all) cout << "Running analysis class MCFakeRateClosureTest.C" << endl;
   if (do_fakes) cout << "Running analysis class MCFakeRateClosureTestWithFakes.C" << endl;
+  else cout << "Running analysis class MCFakeRateClosureTest.C" << endl;
   cout << endl;
   
   // use stopwatch for timing
@@ -40,9 +24,8 @@ void diphoton_looper() {
 
   // select tree
   TString tree = "";
-  if (do_all) tree = "diphoton/fTree";
   if (do_fakes) tree = "diphoton/fTreeFake";
-
+  else tree = "diphoton/fTree";
   cout << "Using tree: " << tree << endl;
   
   // ntuple path (change as needed)
@@ -50,44 +33,110 @@ void diphoton_looper() {
   
   // create tchain of all files to loop over
   TChain *chain = new TChain(tree);
-  
-  if (sample == "all" || sample == "QCD") {
-    // chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_5to10_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0); 
-    // chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_10to15_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    // chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_15to30_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    // chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_30to50_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_50to80_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_80to120_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_120to170_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_170to300_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_300to470_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
-  }
-  
-  if (sample == "all" || sample == "GJets") {
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GJets_HT-40To100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GJets_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GJets_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GJets_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_merged.root",0);
-  }
 
-  if (/*sample == "all" || */sample == "GGJets") {
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GGJets_M-60To200_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GGJets_M-200To500_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GGJets_M-500To1000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GGJets_M-1000To2000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GGJets_M-2000To4000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GGJets_M-4000To6000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GGJets_M-6000To8000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
-    chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GGJets_M-8000To13000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
+  if (run == "2016") {  
+    if (sample == "all" || sample == "QCD") {
+      // chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_5to10_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0); 
+      // chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_10to15_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      // chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_15to30_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      // chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_30to50_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_50to80_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_80to120_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_120to170_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_170to300_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_300to470_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8_76X_MiniAOD_merged.root",0);
+    }
+  
+    if (sample == "all" || sample == "GJets") {
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GJets_HT-40To100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GJets_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GJets_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GJets_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_76X_MiniAOD_merged.root",0);
+    }
+
+    if (sample == "GGJets") {
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GGJets_M-60To200_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GGJets_M-200To500_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GGJets_M-500To1000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GGJets_M-1000To2000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GGJets_M-2000To4000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GGJets_M-4000To6000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GGJets_M-6000To8000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
+      chain->Add("root://cmsxrootd.fnal.gov/"+ntuple_path+"/diphoton_fake_rate_closure_test_GGJets_M-8000To13000_Pt-50_13TeV-sherpa_76X_MiniAOD_merged.root",0);
+    }
+  }
+  if (run == "2017") {
+    if (sample == "all" || sample == "GJets") {
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8__Fall17-v2__MINIAODSIM_resub/200904_\
+235904/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8__Fall17-v1__MINIAODSIM_resub/20090\
+5_000007/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8__Fall17-v1__MINIAODSIM_resub/20090\
+5_000330/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8__Fall17-v1__MINIAODSIM_resub/20090\
+5_000726/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8__Fall17-v2__MINIAODSIM_resub/20090\
+5_000637/0000/*.root");
+    }
+    if (sample == "all" || sample == "GGJets") {
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-60To200_Pt-50_13TeV-sherpa/crab_GGJets_M-60To200_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/200904_23343\
+9/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-200To500_Pt-50_13TeV-sherpa/crab_GGJets_M-200To500_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/200904_232\
+918/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-500To1000_Pt-50_13TeV-sherpa/crab_GGJets_M-500To1000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/200904_2\
+33026/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-1000To2000_Pt-50_13TeV-sherpa/crab_GGJets_M-1000To2000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/200904\
+_232739/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-2000To4000_Pt-50_13TeV-sherpa/crab_GGJets_M-2000To4000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v2__MINIAODSIM_resub/200904\
+_233559/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-4000To6000_Pt-50_13TeV-sherpa/crab_GGJets_M-4000To6000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v2__MINIAODSIM_resub/200904\
+_233641/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-6000To8000_Pt-50_13TeV-sherpa/crab_GGJets_M-6000To8000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/200904\
+_233321/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-8000To13000_Pt-50_13TeV-sherpa/crab_GGJets_M-8000To13000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/2009\
+04_233735/0000/*.root");
+    }
+  }
+  if (run == "2018") {
+    if (sample == "all" || sample == "GJets") {
+      chain->Add(ntuple_path+"diphoton_closure/11c96ff/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8__RunIIAutumn18MiniAOD-102X_upgrade20\
+18_realistic/200821_031620/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/11c96ff/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8__RunIIAutumn18MiniAOD-4cores5k_102\
+X_upgrade2018/200821_021447/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/11c96ff/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8__RunIIAutumn18MiniAOD-102X_upgrade\
+2018_realisti/200821_023518/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/11c96ff/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8__RunIIAutumn18MiniAOD-102X_upgrade\
+2018_realisti/200821_025548/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/11c96ff/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8__RunIIAutumn18MiniAOD-102X_upgrade\
+2018_realisti/200821_033205/0000/*.root");
+    }
+    if (sample == "all" || sample == "GGJets") {
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-500To1000_Pt-50_13TeV-sherpa/crab_GGJets_M-500To1000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MINI/\
+200730_042411/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-8000To13000_Pt-50_13TeV-sherpa/crab_GGJets_M-8000To13000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__M\
+I/200730_151230/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-2000To4000_Pt-50_13TeV-sherpa/crab_GGJets_M-2000To4000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MIN\
+/200730_151014/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-6000To8000_Pt-50_13TeV-sherpa/crab_GGJets_M-6000To8000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MIN\
+/200730_151138/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-4000To6000_Pt-50_13TeV-sherpa/crab_GGJets_M-4000To6000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MIN\
+/200730_151111/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-1000To2000_Pt-50_13TeV-sherpa/crab_GGJets_M-1000To2000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MIN\
+/200730_150946/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-60To200_Pt-50_13TeV-sherpa/crab_GGJets_M-60To200_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MINIAO/20\
+0730_151203/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-200To500_Pt-50_13TeV-sherpa/crab_GGJets_M-200To500_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MINIA/2\
+00730_151042/0000/*.root");
+    }
   }
   
   // list chain and entries
@@ -95,13 +144,13 @@ void diphoton_looper() {
   cout << "Total number of entries: " << chain->GetEntries() << endl;
   
   // create instance using our chain and loop over entries
-  if (do_all) {
-    MCFakeRateClosureTest loop_all(chain);
-    loop_all.Loop();
-  }
   if (do_fakes) {
     MCFakeRateClosureTestWithFakes loop_fakes(chain);
-    loop_fakes.Loop();
+    loop_fakes.Loop(run, sample);
+  }
+  else {
+    MCFakeRateClosureTest loop_all(chain);
+    loop_all.Loop(run, sample);
   }
   
   // stop stopwatch

--- a/FakeRateAnalysis/PhotonClosureTest/scripts/diphoton_looper.C
+++ b/FakeRateAnalysis/PhotonClosureTest/scripts/diphoton_looper.C
@@ -76,66 +76,40 @@ void diphoton_looper(TString run, TString sample, bool do_fakes) {
   }
   if (run == "2017") {
     if (sample == "all" || sample == "GJets") {
-      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8__Fall17-v2__MINIAODSIM_resub/200904_\
-235904/0000/*.root");
-      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8__Fall17-v1__MINIAODSIM_resub/20090\
-5_000007/0000/*.root");
-      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8__Fall17-v1__MINIAODSIM_resub/20090\
-5_000330/0000/*.root");
-      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8__Fall17-v1__MINIAODSIM_resub/20090\
-5_000726/0000/*.root");
-      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8__Fall17-v2__MINIAODSIM_resub/20090\
-5_000637/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8__Fall17-v2__MINIAODSIM_resub/200904_235904/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8__Fall17-v1__MINIAODSIM_resub/200905_000007/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8__Fall17-v1__MINIAODSIM_resub/200905_000330/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8__Fall17-v1__MINIAODSIM_resub/200905_000726/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8__Fall17-v2__MINIAODSIM_resub/200905_000637/0000/*.root");
     }
     if (sample == "all" || sample == "GGJets") {
-      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-60To200_Pt-50_13TeV-sherpa/crab_GGJets_M-60To200_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/200904_23343\
-9/0000/*.root");
-      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-200To500_Pt-50_13TeV-sherpa/crab_GGJets_M-200To500_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/200904_232\
-918/0000/*.root");
-      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-500To1000_Pt-50_13TeV-sherpa/crab_GGJets_M-500To1000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/200904_2\
-33026/0000/*.root");
-      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-1000To2000_Pt-50_13TeV-sherpa/crab_GGJets_M-1000To2000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/200904\
-_232739/0000/*.root");
-      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-2000To4000_Pt-50_13TeV-sherpa/crab_GGJets_M-2000To4000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v2__MINIAODSIM_resub/200904\
-_233559/0000/*.root");
-      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-4000To6000_Pt-50_13TeV-sherpa/crab_GGJets_M-4000To6000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v2__MINIAODSIM_resub/200904\
-_233641/0000/*.root");
-      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-6000To8000_Pt-50_13TeV-sherpa/crab_GGJets_M-6000To8000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/200904\
-_233321/0000/*.root");
-      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-8000To13000_Pt-50_13TeV-sherpa/crab_GGJets_M-8000To13000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/2009\
-04_233735/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-60To200_Pt-50_13TeV-sherpa/crab_GGJets_M-60To200_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/200904_233439/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-200To500_Pt-50_13TeV-sherpa/crab_GGJets_M-200To500_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/200904_232918/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-500To1000_Pt-50_13TeV-sherpa/crab_GGJets_M-500To1000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/200904_233026/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-1000To2000_Pt-50_13TeV-sherpa/crab_GGJets_M-1000To2000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/200904_232739/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-2000To4000_Pt-50_13TeV-sherpa/crab_GGJets_M-2000To4000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v2__MINIAODSIM_resub/200904_233559/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-4000To6000_Pt-50_13TeV-sherpa/crab_GGJets_M-4000To6000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v2__MINIAODSIM_resub/200904_233641/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-6000To8000_Pt-50_13TeV-sherpa/crab_GGJets_M-6000To8000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/200904_233321/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/2c8bbea/GGJets_M-8000To13000_Pt-50_13TeV-sherpa/crab_GGJets_M-8000To13000_Pt-50_13TeV-sherpa__Fall17_94X_mc2017_realistic_v14-v1__MINIAODSIM_resub/200904_233735/0000/*.root");
     }
   }
   if (run == "2018") {
     if (sample == "all" || sample == "GJets") {
-      chain->Add(ntuple_path+"diphoton_closure/11c96ff/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8__RunIIAutumn18MiniAOD-102X_upgrade20\
-18_realistic/200821_031620/0000/*.root");
-      chain->Add(ntuple_path+"diphoton_closure/11c96ff/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8__RunIIAutumn18MiniAOD-4cores5k_102\
-X_upgrade2018/200821_021447/0000/*.root");
-      chain->Add(ntuple_path+"diphoton_closure/11c96ff/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8__RunIIAutumn18MiniAOD-102X_upgrade\
-2018_realisti/200821_023518/0000/*.root");
-      chain->Add(ntuple_path+"diphoton_closure/11c96ff/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8__RunIIAutumn18MiniAOD-102X_upgrade\
-2018_realisti/200821_025548/0000/*.root");
-      chain->Add(ntuple_path+"diphoton_closure/11c96ff/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8__RunIIAutumn18MiniAOD-102X_upgrade\
-2018_realisti/200821_033205/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/11c96ff/GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-40To100_TuneCP5_13TeV-madgraphMLM-pythia8__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic/200821_031620/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/11c96ff/GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8__RunIIAutumn18MiniAOD-4cores5k_102X_upgrade2018/200821_021447/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/11c96ff/GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8__RunIIAutumn18MiniAOD-102X_upgrade2018_realisti/200821_023518/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/11c96ff/GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8__RunIIAutumn18MiniAOD-102X_upgrade2018_realisti/200821_025548/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/11c96ff/GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/crab_GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8__RunIIAutumn18MiniAOD-102X_upgrade2018_realisti/200821_033205/0000/*.root");
     }
     if (sample == "all" || sample == "GGJets") {
-      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-500To1000_Pt-50_13TeV-sherpa/crab_GGJets_M-500To1000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MINI/\
-200730_042411/0000/*.root");
-      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-8000To13000_Pt-50_13TeV-sherpa/crab_GGJets_M-8000To13000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__M\
-I/200730_151230/0000/*.root");
-      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-2000To4000_Pt-50_13TeV-sherpa/crab_GGJets_M-2000To4000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MIN\
-/200730_151014/0000/*.root");
-      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-6000To8000_Pt-50_13TeV-sherpa/crab_GGJets_M-6000To8000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MIN\
-/200730_151138/0000/*.root");
-      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-4000To6000_Pt-50_13TeV-sherpa/crab_GGJets_M-4000To6000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MIN\
-/200730_151111/0000/*.root");
-      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-1000To2000_Pt-50_13TeV-sherpa/crab_GGJets_M-1000To2000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MIN\
-/200730_150946/0000/*.root");
-      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-60To200_Pt-50_13TeV-sherpa/crab_GGJets_M-60To200_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MINIAO/20\
-0730_151203/0000/*.root");
-      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-200To500_Pt-50_13TeV-sherpa/crab_GGJets_M-200To500_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MINIA/2\
-00730_151042/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-500To1000_Pt-50_13TeV-sherpa/crab_GGJets_M-500To1000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MINI/200730_042411/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-8000To13000_Pt-50_13TeV-sherpa/crab_GGJets_M-8000To13000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MI/200730_151230/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-2000To4000_Pt-50_13TeV-sherpa/crab_GGJets_M-2000To4000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MIN/200730_151014/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-6000To8000_Pt-50_13TeV-sherpa/crab_GGJets_M-6000To8000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MIN/200730_151138/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-4000To6000_Pt-50_13TeV-sherpa/crab_GGJets_M-4000To6000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MIN/200730_151111/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-1000To2000_Pt-50_13TeV-sherpa/crab_GGJets_M-1000To2000_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MIN/200730_150946/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-60To200_Pt-50_13TeV-sherpa/crab_GGJets_M-60To200_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MINIAO/200730_151203/0000/*.root");
+      chain->Add(ntuple_path+"diphoton_closure/27a1c52/GGJets_M-200To500_Pt-50_13TeV-sherpa/crab_GGJets_M-200To500_Pt-50_13TeV-sherpa__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1__MINIA/200730_151042/0000/*.root");
     }
   }
   

--- a/FakeRateAnalysis/RealTemplateAnalysis/analysis/MCFakeRateAnalysis.C
+++ b/FakeRateAnalysis/RealTemplateAnalysis/analysis/MCFakeRateAnalysis.C
@@ -7,12 +7,10 @@
 #include <map>
 #include <iostream>
 
+#include "diphoton-analysis/FakeRateAnalysis/interface/utilities.hh"
+
 void MCFakeRateAnalysis::Loop(int year, const std::string & sample, int pvCutLow = 0, int pvCutHigh = 500)
 {
-  std::map<int, TString> cmssw_version;
-  cmssw_version[2016] = "76X";
-  cmssw_version[2017] = "94X";
-  cmssw_version[2018] = "102X";
 
 //   In a ROOT session, you can do:
 //      root> .L MCFakeRateAnalysis.C
@@ -41,10 +39,10 @@ void MCFakeRateAnalysis::Loop(int year, const std::string & sample, int pvCutLow
   
   TString pv = Form("_nPV%i-%i", pvCutLow, pvCutHigh);
   TString filename = "";
-  if (sample == "DiPhotonJets") filename = "diphoton_fake_rate_real_templates_DiPhotonJets_MGG-80toInf_13TeV_amcatnloFXFX_pythia8_" + cmssw_version[year] + pv + "_MiniAOD_histograms.root";
-  if (sample == "GGJets")       filename = "diphoton_fake_rate_real_templates_GGJets_M-all_Pt-50_13TeV-sherpa_" + cmssw_version[year] + pv + "_MiniAOD_histograms.root";
-  if (sample == "GJets")        filename = "diphoton_fake_rate_real_templates_GJets_HT-all_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_" + cmssw_version[year] + pv + "_MiniAOD_histograms.root";
-  if (sample == "all")          filename = "diphoton_fake_rate_real_templates_all_GGJets_GJets_" + cmssw_version[year] + pv + "_MiniAOD_histograms.root";
+  if (sample == "DiPhotonJets") filename = "diphoton_fake_rate_real_templates_DiPhotonJets_MGG-80toInf_13TeV_amcatnloFXFX_pythia8_" + cmssw_version(year) + pv + "_MiniAOD_histograms.root";
+  if (sample == "GGJets")       filename = "diphoton_fake_rate_real_templates_GGJets_M-all_Pt-50_13TeV-sherpa_" + cmssw_version(year) + pv + "_MiniAOD_histograms.root";
+  if (sample == "GJets")        filename = "diphoton_fake_rate_real_templates_GJets_HT-all_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_" + cmssw_version(year) + pv + "_MiniAOD_histograms.root";
+  if (sample == "all")          filename = "diphoton_fake_rate_real_templates_all_GGJets_GJets_" + cmssw_version(year) + pv + "_MiniAOD_histograms.root";
   
   std::cout << "\nOutput filename: " << filename << std::endl << std::endl;
   

--- a/FakeRateAnalysis/bin/BuildFile.xml
+++ b/FakeRateAnalysis/bin/BuildFile.xml
@@ -10,5 +10,7 @@
   <bin file="compare_pv_years.cc" name="compare_pv_years.exe"/>
   <bin file="compare_denominator.cc" name="compare_denominator.exe"/>
   <bin file="compare_numerator.cc" name="compare_numerator.exe"/>
+  <bin file="photon_closure_test.cc" name="photon_closure_test.exe"/>
+  <bin file="diphoton_closure_test.cc" name="diphoton_closure_test.exe"/>
 </environment>
 <flags CXXFLAGS="-Wall -g"/>

--- a/FakeRateAnalysis/bin/diphoton_closure_test.cc
+++ b/FakeRateAnalysis/bin/diphoton_closure_test.cc
@@ -1,0 +1,35 @@
+#include "diphoton-analysis/FakeRateAnalysis/DiphotonClosureTest/scripts/diphoton_looper.C"
+
+#include <iostream>
+
+int main(int argc, char *argv[])
+{
+  std::string samples, run;
+
+  if(argc!=3) {
+    std::cout << "Syntax: closure_test.exe [2016/2017/2018] [QCD/GJets/GGJets/all]" << std::endl;
+    return -1;
+  }
+  else {
+    run = argv[1];
+    if(run.find("2016") != std::string::npos
+       and run.find("2017") != std::string::npos
+       and run.find("2018") != std::string::npos) {
+      std::cout << "Only '2016', '2017', and '2018' are allowed years." << std::endl;
+      return -1;
+    }
+    samples = argv[2];
+    if(samples.compare("QCD") != 0 
+       and samples.compare("GJets") != 0
+       and samples.compare("GGJets") != 0
+       and samples.compare("QCD") != 0
+       and samples.compare("all") != 0) {
+      std::cout << "Only 'QCD', 'GJets', 'GGJets' and 'all' are allowed samples. " << std::endl;
+      return -1;
+    }
+  }
+
+  diphoton_looper(run, samples);
+
+  return 0;
+}

--- a/FakeRateAnalysis/bin/photon_closure_test.cc
+++ b/FakeRateAnalysis/bin/photon_closure_test.cc
@@ -1,0 +1,42 @@
+#include "diphoton-analysis/FakeRateAnalysis/PhotonClosureTest/scripts/diphoton_looper.C"
+
+#include <iostream>
+
+int main(int argc, char *argv[])
+{
+  std::string samples, run, fakes;
+
+  if(argc != 4) {
+    std::cout << "Syntax: closure_test.exe [2016/2017/2018] [QCD/GJets/GGJets/all] [fakes/all]" << std::endl;
+    return -1;
+  }
+  else {
+    run = argv[1];
+    if(run.find("2016") != std::string::npos
+       and run.find("2017") != std::string::npos
+       and run.find("2018") != std::string::npos) {
+      std::cout << "Only '2016', '2017', and '2018' are allowed years." << std::endl;
+      return -1;
+    }
+    samples = argv[2];
+    if(samples.compare("QCD") != 0 
+       and samples.compare("GJets") != 0
+       and samples.compare("GGJets") != 0
+       and samples.compare("QCD") != 0
+       and samples.compare("all") != 0) {
+      std::cout << "Only 'QCD', 'GJets', 'GGJets' and 'all' are allowed samples. " << std::endl;
+      return -1;
+    }
+    fakes = argv[3];
+    if(fakes.compare("fakes") != 0 
+       and fakes.compare("all") != 0) {
+      std::cout << "Only 'fakes' and 'all' are allowed parameters. " << std::endl;
+      return -1;
+    }
+  }
+  bool do_fakes = fakes.compare("fakes");
+
+  diphoton_looper(run, samples, do_fakes);
+
+  return 0;
+}

--- a/FakeRateAnalysis/interface/utilities.hh
+++ b/FakeRateAnalysis/interface/utilities.hh
@@ -1,0 +1,13 @@
+#ifndef FAKERATEANALYSIS_UTILITIES_HH
+#define FAKERATEANALYSIS_UTILITIES_HH
+
+TString cmssw_version(int year)
+{
+  std::map<int, TString> cmssw_version_map;
+  cmssw_version_map[2016] = "76X";
+  cmssw_version_map[2017] = "94X";
+  cmssw_version_map[2018] = "102X";
+
+  return cmssw_version_map[year];
+}
+#endif


### PR DESCRIPTION
This PR adds code to extend the closure test to 2017 and 2018. It does not yet include the code to use the fake rate parameterization from 2017 and 2018 but still uses the hardcoded 2016 fake rate. This will be fixed in a further update.